### PR TITLE
Adds Selectable rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ This will enable you to modify the blade views and apply your own styling, the d
 |**per-page**|*Integer* default: 10|Number of rows per page| ```per-page="20"``` |
 |**exportable**|*Boolean*  default: *false*|Allows tabel to bbe exported| ```<livewire:datatable model="App/Post" exportable />``` |
 |**hideable**| _String_ | gives ability to show/hide columns, accepts strings 'inline', 'buttons', or 'select'| ```<livewire:datatable model="App/Post" hideable="inline" />``` |
+|**beforeTableSlot**| _String_ |blade view to be included immediately before the table in the component, which can therefore access public properties|  |
+|**afterTableSlot**| _String_ |blade view to be included immediately after the table in the component, which can therefore access public properties| [demo](https://livewire-datatables.com/complex) |
 ---
 
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ class ComplexDemoTable extends LivewireDatatable
 
     public function columns()
     {
-        return Columnset::fromArray([
+        return [
             NumberColumn::name('id')
                 ->label('ID')
                 ->linkTo('job', 6),
@@ -140,7 +140,7 @@ class ComplexDemoTable extends LivewireDatatable
                 ->label('DOB')
                 ->filterable()
                 ->hide()
-        ]);
+        ];
     }
 }
 ```
@@ -153,6 +153,7 @@ class ComplexDemoTable extends LivewireDatatable
 |_static_ **callback**|*Array\|String* $columns, *Closure\|String* $callback| Passes the columns from the first argument into the callback to allow custom mutations. The callback can be a method on the table class, or inline | _(see below)_|
 |_static_ **scope**|*String* $scope, *String* $alias|Builds a column from a scope on the parent model|```Column::scope('selectLastLogin', 'Last Login')```|
 |_static_ **delete**|[*String* $primaryKey default: 'id']|Adds a column with a delete button, which will call ```$this->model::destroy($primaryKey)```|```Column::delete()```|
+|_static_ **checkbox**|[*String* $column default: 'id']|Adds a column with a checkbox. The component public property ```$selected``` will contain an array of the named column from checked rows, |```Column::checkbox()```|
 |**label**|*String* $name|Changes the display name of a column|```Column::name('id')->label('ID)```|
 |**format**|[*String* $format]|Formats the column value according to type. Dates/times will use the default format or the argument |```Column::name('email_verified_at')->filterable(),```|
 |**hide**| |Marks column to start as hidden|```Column::name('id')->hidden()```|

--- a/resources/views/livewire/datatables/checkbox.blade.php
+++ b/resources/views/livewire/datatables/checkbox.blade.php
@@ -1,0 +1,3 @@
+<div class="flex justify-center">
+    <input type="checkbox" wire:model="selected" value="{{ $value }}" class="form-checkbox mt-1 h-4 w-4 text-blue-600 transition duration-150 ease-in-out" />
+</div>

--- a/resources/views/livewire/datatables/datatable.blade.php
+++ b/resources/views/livewire/datatables/datatable.blade.php
@@ -1,153 +1,165 @@
-<div class="relative">
-    <div class="flex justify-between items-center mb-1">
-        <div class="flex-grow h-10 flex items-center">
-            @if($this->searchableColumns()->count())
-            <div class="w-96 flex rounded-lg shadow-sm">
-                <div class="relative flex-grow focus-within:z-10">
-                    <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                        <svg class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" stroke="currentColor" fill="none">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                        </svg>
-                    </div>
-                    <input wire:model.debounce.500ms="search" class="form-input block bg-gray-50 focus:bg-white w-full rounded-md pl-10 transition ease-in-out duration-150 sm:text-sm sm:leading-5" placeholder="Search in {{ $this->searchableColumns()->map->label->join(', ') }}" />
-                    <div class="absolute inset-y-0 right-0 pr-3 flex items-center">
-                        <button wire:click="$set('search', null)" class="text-gray-300 hover:text-red-600 focus:outline-none">
-                            <x-icons.x-circle class="h-5 w-5 stroke-current" />
-                        </button>
-                    </div>
-                </div>
-            </div>
-            @endif
+<div>
+    @if($beforeTableSlot)
+        <div class="mt-8">
+            @include($beforeTableSlot)
         </div>
-
-        <div class="flex items-center space-x-1">
-            <x-icons.cog wire:loading class="h-9 w-9 animate-spin text-gray-400" />
-
-            @if($exportable)
-            <div x-data="{ init() {
-                window.livewire.on('startDownload', link => window.open(link,'_blank'))
-            } }" x-init="init">
-                <button wire:click="export" class="flex items-center space-x-2 px-3 border border-green-400 rounded-md bg-white text-green-500 text-xs leading-4 font-medium uppercase tracking-wider hover:bg-green-200 focus:outline-none"><span>Export</span>
-                    <x-icons.excel class="m-2" /></button>
-            </div>
-            @endif
-
-            @if($hideable === 'select')
-            @include('datatables::hide-column-multiselect')
-            @endif
-        </div>
-    </div>
-
-    @if($hideable === 'buttons')
-    <div class="p-2 grid grid-cols-8 gap-2">
-        @foreach($this->columns as $index => $column)
-        <button wire:click.prefetch="toggle('{{ $index }}')" class="px-3 py-2 rounded text-white text-xs focus:outline-none
-        {{ $column['hidden'] ? 'bg-blue-100 hover:bg-blue-300 text-blue-600' : 'bg-blue-500 hover:bg-blue-800' }}">
-            {{ $column['label'] }}
-        </button>
-        @endforeach
-    </div>
     @endif
-
-    <div class="rounded-lg shadow-lg bg-white">
-        <div class="rounded-lg @unless($this->hidePagination) rounded-b-none @endif max-w-screen overflow-x-scroll bg-white">
-            <div class="table align-middle min-w-full">
-                @unless($this->hideHeader)
-                <div class="table-row divide-x divide-gray-200">
-                    @foreach($this->columns as $index => $column)
-                        @if($hideable === 'inline')
-                            @include('datatables::header-inline-hide', ['column' => $column, 'sort' => $sort])
-                        @elseif($column['type'] === 'checkbox')
-                        <div class="relative table-cell h-12 w-48 overflow-hidden align-top px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex items-center focus:outline-none">
-                            <div class="px-3 py-1 rounded @if(count($selected)) bg-orange-400 @else bg-gray-200 @endif text-white text-center">
-                                {{ count($selected) }}
-                            </div>
+    <div class="relative">
+        <div class="flex justify-between items-center mb-1">
+            <div class="flex-grow h-10 flex items-center">
+                @if($this->searchableColumns()->count())
+                <div class="w-96 flex rounded-lg shadow-sm">
+                    <div class="relative flex-grow focus-within:z-10">
+                        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                            <svg class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" stroke="currentColor" fill="none">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
                         </div>
-                        @else
-                            @include('datatables::header-no-hide', ['column' => $column, 'sort' => $sort])
-                        @endif
-                    @endforeach
-                </div>
-
-                <div class="table-row divide-x divide-blue-200 bg-blue-100">
-                    @foreach($this->columns as $index => $column)
-                        @if($column['hidden'])
-                            @if($hideable === 'inline')
-                                <div class="table-cell w-5 overflow-hidden align-top bg-blue-100"></div>
-                            @endif
-                        @elseif($column['type'] === 'checkbox')
-                            <div class="w-32 overflow-hidden align-top bg-blue-100 px-6 py-5 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex h-full flex-col items-center space-y-2 focus:outline-none">
-                                <div>SELECT ALL</div>
-                                <div>
-                                    <input type="checkbox" wire:click="toggleSelectAll" @if(count($selected) === $this->results->total()) checked @endif class="form-checkbox mt-1 h-4 w-4 text-blue-600 transition duration-150 ease-in-out" />
-                                </div>
-                            </div>
-                        @else
-                            <div class="table-cell overflow-hidden align-top">
-                                @isset($column['filterable'])
-                                    @if( is_iterable($column['filterable']) )
-                                        <div wire:key="{{ $index }}">
-                                            @include('datatables::filters.select', ['index' => $index, 'name' => $column['label'], 'options' => $column['filterable']])
-                                        </div>
-                                    @else
-                                        <div wire:key="{{ $index }}">
-                                            @include('datatables::filters.' . ($column['filterView'] ?? $column['type']), ['index' => $index, 'name' => $column['label']])
-                                        </div>
-                                    @endif
-                                @endisset
-                            </div>
-                        @endif
-                    @endforeach
+                        <input wire:model.debounce.500ms="search" class="form-input block bg-gray-50 focus:bg-white w-full rounded-md pl-10 transition ease-in-out duration-150 sm:text-sm sm:leading-5" placeholder="Search in {{ $this->searchableColumns()->map->label->join(', ') }}" />
+                        <div class="absolute inset-y-0 right-0 pr-3 flex items-center">
+                            <button wire:click="$set('search', null)" class="text-gray-300 hover:text-red-600 focus:outline-none">
+                                <x-icons.x-circle class="h-5 w-5 stroke-current" />
+                            </button>
+                        </div>
+                    </div>
                 </div>
                 @endif
-                @foreach($this->results as $result)
-                <div class="table-row p-1 divide-x divide-gray-100 {{ isset($result->checkbox_attribute) && in_array($result->checkbox_attribute, $selected) ? 'bg-orange-100' : ($loop->even ? 'bg-gray-100' : 'bg-gray-50') }}">
-                    @foreach($this->columns as $column)
-                        @if($column['hidden'])
-                            @if($hideable === 'inline')
-                            <div class="table-cell w-5 overflow-hidden align-top"></div>
-                            @endif
-                        @elseif($column['type'] === 'checkbox')
-                            @include('datatables::checkbox', ['value' => $result->checkbox_attribute])
-                        @else
-                            <div class="px-6 py-2 whitespace-no-wrap text-sm leading-5 text-gray-900 table-cell @if($column['align'] === 'right') text-right @elseif($column['align'] === 'center') text-center @else text-left @endif">
-                                {!! $result->{$column['name']} !!}
-                            </div>
-                        @endif
-                    @endforeach
+            </div>
+
+            <div class="flex items-center space-x-1">
+                <x-icons.cog wire:loading class="h-9 w-9 animate-spin text-gray-400" />
+
+                @if($exportable)
+                <div x-data="{ init() {
+                    window.livewire.on('startDownload', link => window.open(link,'_blank'))
+                } }" x-init="init">
+                    <button wire:click="export" class="flex items-center space-x-2 px-3 border border-green-400 rounded-md bg-white text-green-500 text-xs leading-4 font-medium uppercase tracking-wider hover:bg-green-200 focus:outline-none"><span>Export</span>
+                        <x-icons.excel class="m-2" /></button>
                 </div>
-                @endforeach
+                @endif
+
+                @if($hideable === 'select')
+                @include('datatables::hide-column-multiselect')
+                @endif
             </div>
         </div>
-        @unless($this->hidePagination)
-        <div class="rounded-lg rounded-t-none max-w-screen rounded-lg border-b border-gray-200 bg-white">
-            <div class="p-2 flex items-center justify-between">
-                <div class="flex items-center">
-                    <select name="perPage" class="mt-1 form-select block w-full pl-3 pr-10 py-2 text-base leading-6 border-gray-300 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5" wire:model="perPage">
-                        <option value="10">10</option>
-                        <option value="25">25</option>
-                        <option value="50">50</option>
-                        <option value="100">100</option>
-                        <option value="99999999">All</option>
-                    </select>
-                </div>
 
-                <div>
-                    <div class="flex lg:hidden justify-center">
-                        <span class="flex items-center space-x-2">{{ $this->results->links('datatables::tailwind-simple-pagination') }}</span>
-                    </div>
-
-                    <div class="hidden lg:flex justify-center">
-                        <span>{{ $this->results->links('datatables::tailwind-pagination') }}</span>
-                    </div>
-                </div>
-
-                <div class="text-gray-600">
-                    Results {{ $this->results->firstItem() }} - {{ $this->results->lastItem() }} of
-                    {{ $this->results->total() }}
-                </div>
-            </div>
+        @if($hideable === 'buttons')
+        <div class="p-2 grid grid-cols-8 gap-2">
+            @foreach($this->columns as $index => $column)
+            <button wire:click.prefetch="toggle('{{ $index }}')" class="px-3 py-2 rounded text-white text-xs focus:outline-none
+            {{ $column['hidden'] ? 'bg-blue-100 hover:bg-blue-300 text-blue-600' : 'bg-blue-500 hover:bg-blue-800' }}">
+                {{ $column['label'] }}
+            </button>
+            @endforeach
         </div>
         @endif
+
+        <div class="rounded-lg shadow-lg bg-white">
+            <div class="rounded-lg @unless($this->hidePagination) rounded-b-none @endif max-w-screen overflow-x-scroll bg-white">
+                <div class="table align-middle min-w-full">
+                    @unless($this->hideHeader)
+                    <div class="table-row divide-x divide-gray-200">
+                        @foreach($this->columns as $index => $column)
+                            @if($hideable === 'inline')
+                                @include('datatables::header-inline-hide', ['column' => $column, 'sort' => $sort])
+                            @elseif($column['type'] === 'checkbox')
+                            <div class="relative table-cell h-12 w-48 overflow-hidden align-top px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex items-center focus:outline-none">
+                                <div class="px-3 py-1 rounded @if(count($selected)) bg-orange-400 @else bg-gray-200 @endif text-white text-center">
+                                    {{ count($selected) }}
+                                </div>
+                            </div>
+                            @else
+                                @include('datatables::header-no-hide', ['column' => $column, 'sort' => $sort])
+                            @endif
+                        @endforeach
+                    </div>
+
+                    <div class="table-row divide-x divide-blue-200 bg-blue-100">
+                        @foreach($this->columns as $index => $column)
+                            @if($column['hidden'])
+                                @if($hideable === 'inline')
+                                    <div class="table-cell w-5 overflow-hidden align-top bg-blue-100"></div>
+                                @endif
+                            @elseif($column['type'] === 'checkbox')
+                                <div class="w-32 overflow-hidden align-top bg-blue-100 px-6 py-5 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex h-full flex-col items-center space-y-2 focus:outline-none">
+                                    <div>SELECT ALL</div>
+                                    <div>
+                                        <input type="checkbox" wire:click="toggleSelectAll" @if(count($selected) === $this->results->total()) checked @endif class="form-checkbox mt-1 h-4 w-4 text-blue-600 transition duration-150 ease-in-out" />
+                                    </div>
+                                </div>
+                            @else
+                                <div class="table-cell overflow-hidden align-top">
+                                    @isset($column['filterable'])
+                                        @if( is_iterable($column['filterable']) )
+                                            <div wire:key="{{ $index }}">
+                                                @include('datatables::filters.select', ['index' => $index, 'name' => $column['label'], 'options' => $column['filterable']])
+                                            </div>
+                                        @else
+                                            <div wire:key="{{ $index }}">
+                                                @include('datatables::filters.' . ($column['filterView'] ?? $column['type']), ['index' => $index, 'name' => $column['label']])
+                                            </div>
+                                        @endif
+                                    @endisset
+                                </div>
+                            @endif
+                        @endforeach
+                    </div>
+                    @endif
+                    @foreach($this->results as $result)
+                    <div class="table-row p-1 divide-x divide-gray-100 {{ isset($result->checkbox_attribute) && in_array($result->checkbox_attribute, $selected) ? 'bg-orange-100' : ($loop->even ? 'bg-gray-100' : 'bg-gray-50') }}">
+                        @foreach($this->columns as $column)
+                            @if($column['hidden'])
+                                @if($hideable === 'inline')
+                                <div class="table-cell w-5 overflow-hidden align-top"></div>
+                                @endif
+                            @elseif($column['type'] === 'checkbox')
+                                @include('datatables::checkbox', ['value' => $result->checkbox_attribute])
+                            @else
+                                <div class="px-6 py-2 whitespace-no-wrap text-sm leading-5 text-gray-900 table-cell @if($column['align'] === 'right') text-right @elseif($column['align'] === 'center') text-center @else text-left @endif">
+                                    {!! $result->{$column['name']} !!}
+                                </div>
+                            @endif
+                        @endforeach
+                    </div>
+                    @endforeach
+                </div>
+            </div>
+            @unless($this->hidePagination)
+            <div class="rounded-lg rounded-t-none max-w-screen rounded-lg border-b border-gray-200 bg-white">
+                <div class="p-2 flex items-center justify-between">
+                    <div class="flex items-center">
+                        <select name="perPage" class="mt-1 form-select block w-full pl-3 pr-10 py-2 text-base leading-6 border-gray-300 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5" wire:model="perPage">
+                            <option value="10">10</option>
+                            <option value="25">25</option>
+                            <option value="50">50</option>
+                            <option value="100">100</option>
+                            <option value="99999999">All</option>
+                        </select>
+                    </div>
+
+                    <div>
+                        <div class="flex lg:hidden justify-center">
+                            <span class="flex items-center space-x-2">{{ $this->results->links('datatables::tailwind-simple-pagination') }}</span>
+                        </div>
+
+                        <div class="hidden lg:flex justify-center">
+                            <span>{{ $this->results->links('datatables::tailwind-pagination') }}</span>
+                        </div>
+                    </div>
+
+                    <div class="text-gray-600">
+                        Results {{ $this->results->firstItem() }} - {{ $this->results->lastItem() }} of
+                        {{ $this->results->total() }}
+                    </div>
+                </div>
+            </div>
+            @endif
+        </div>
     </div>
+    @if($afterTableSlot)
+    <div class="mt-8">
+        @include($afterTableSlot)
+    </div>
+    @endif
 </div>

--- a/src/Column.php
+++ b/src/Column.php
@@ -67,6 +67,11 @@ class Column
         return $column;
     }
 
+    public static function checkbox($attribute = 'id')
+    {
+        return static::name($attribute . ' as checkbox_attribute')->setType('checkbox');
+    }
+
     public static function scope($scope, $alias)
     {
         $column = new static;
@@ -83,10 +88,6 @@ class Column
         return static::callback($name, function ($value) {
             return view('datatables::delete', ['value' => $value]);
         });
-        // $column->name = $name;
-        // $column->label = 'Delete';
-        // $column->callback = ;
-        // return $column;
     }
 
     public function label($label)
@@ -165,8 +166,7 @@ class Column
 
     public function editable()
     {
-        $this->type = 'editable';
-        return $this;
+        return $this->setType('editable');
     }
 
     public function isEditable()
@@ -211,7 +211,7 @@ class Column
 
     public function isBaseColumn()
     {
-        return !Str::contains($this->name, '.') && !$this->raw;
+        return ! Str::contains($this->name, '.') && !$this->raw;
     }
 
     public function field()
@@ -222,5 +222,16 @@ class Column
     public function relations()
     {
         return $this->isBaseColumn() ? null : collect(explode('.', Str::beforeLast($this->name, '.')));
+    }
+
+    public function isType($type)
+    {
+        return $type === $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+        return $this;
     }
 }

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -51,6 +51,8 @@ class LivewireDatatable extends Component
     public $hideable;
     public $params;
     public $selected = [];
+    public $beforeTableSlot;
+    public $afterTableSlot;
 
     protected $query;
     protected $listeners = ['refreshLivewireDatatable'];
@@ -69,9 +71,11 @@ class LivewireDatatable extends Component
         $perPage = 10,
         $exportable = false,
         $hideable = false,
+        $beforeTableSlot = false,
+        $afterTableSlot = false,
         $params = []
     ) {
-        foreach (['model', 'include', 'exclude', 'hide', 'dates', 'times', 'searchable', 'sort', 'hideHeader', 'hidePagination', 'perPage', 'exportable', 'hideable'] as $property) {
+        foreach (['model', 'include', 'exclude', 'hide', 'dates', 'times', 'searchable', 'sort', 'hideHeader', 'hidePagination', 'perPage', 'exportable', 'hideable', 'beforeTableSlot', 'afterTableSlot'] as $property) {
             $this->$property = $this->$property ?? $$property;
         }
 


### PR DESCRIPTION
In response to #13 
- Adds ```Column::select()``` to create seleactable rows
- Component exposes ```$selected``` array of selected rows
- Adds ```$beforeTableSlot``` and ```$afterTableSlot``` to allow users to add additional templates that can access component properties.