### PR TITLE
Add optional parameter to editable() to allow for conditional setting

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -172,9 +172,9 @@ class Column
         return $this;
     }
 
-    public function editable()
+    public function editable($editable = true)
     {
-        return $this->setType('editable');
+        return $editable ? $this->setType('editable') : $this;
     }
 
     public function isEditable()


### PR DESCRIPTION
I have a data set that I want the user to be able to edit if certain conditions are true. This would be most easily accomplished if I could calculate the conditions before creating the column and only setting it to editable if the conditions are met. So what this PR proposes is the addition of an optional parameter to editable(), defaulted to true, that would not set the attribute if the parameter is false. 