### PR TITLE
Values read from the DB should be escaped default

### DIFF
--- a/resources/views/livewire/datatables/editable.blade.php
+++ b/resources/views/livewire/datatables/editable.blade.php
@@ -13,9 +13,9 @@
     }
 }" x-init="init()" :key="{{ $rowId }}">
     <button class="w-full text-left hover:bg-blue-100 px-2 py-1 -mx-2 -my-1 rounded focus:outline-none" x-bind:class="{ 'text-green-600': edited }" x-show="!edit"
-        x-on:click="edit = true; $nextTick(() => { $refs.input.focus() })">{!! $value !!}</button>
+        x-on:click="edit = true; $nextTick(() => { $refs.input.focus() })">{!! htmlspecialchars($value) !!}</button>
     <span x-cloak x-show="edit">
-        <input class="border-blue-400 px-2 py-1 -mx-2 -my-1 rounded focus:outline-none focus:border" x-ref="input" value="{!! strip_tags($value) !!}"
+        <input class="border-blue-400 px-2 py-1 -mx-2 -my-1 rounded focus:outline-none focus:border" x-ref="input" value="{!! htmlspecialchars($value) !!}"
             wire:change="edited($event.target.value, '{{ $table }}', '{{ $column }}', '{{ $rowId }}')"
             x-on:click.away="edit = false" x-on:blur="edit = false" x-on:keydown.enter="edit = false" />
     </span>


### PR DESCRIPTION
Raw html output that can cause simple takeover by displaying user-entered data should be the hard path (another modifier), not the easy one.
Example:
Display results from a table containing <script>alert('woof!');</script>

This could of course be solved centrally and for all colums (since it happens on string columns too) by escaping it in 
https://github.com/MedicOneSystems/livewire-datatables/blob/9645df8f6c9140624a0ec36d0621b033bd76e12c/src/Http/Livewire/LivewireDatatable.php#L945-L950
but i am not sure if that'd cause display/other issues on the table.