### PR TITLE
Make possible to disable highlighting

### DIFF
--- a/config/livewire-datatables.php
+++ b/config/livewire-datatables.php
@@ -3,4 +3,6 @@
 return [
     'default_time_format' => 'H:i',
     'default_date_format' => 'd/m/Y',
+    'suppress_search_highlights' => false, // When searching, don't highlight matching search results when set to true
+
 ];

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -931,7 +931,7 @@ class LivewireDatatable extends Component
                     $row->$name = $this->callbacks[$name]($value, $row);
                 }
 
-                if ($this->search && $this->searchableColumns()->firstWhere('name', $name)) {
+                if ($this->search && ! config('livewire-datatables.suppress_search_highlights') && $this->searchableColumns()->firstWhere('name', $name)) {
                     $row->$name = $this->highlight($row->$name, $this->search);
                 }
             }
@@ -947,6 +947,34 @@ class LivewireDatatable extends Component
         return is_array($this->freshColumns[$index]['filterable']) && is_numeric($value)
             ? collect($this->freshColumns[$index]['filterable'])->firstWhere('id', '=', $value)['name'] ?? $value
             : $value;
+    }
+
+
+    /*  This can be called to apply highlting of the search term to some string.
+     *  Motivation: Call this from your Column::Callback to apply highlight to a chosen section of the result.
+     */
+    public function highlightStringWithCurrentSearchTerm(string $originalString)
+    {
+        if (!$this->search) {
+            return $originalString;
+        } else {
+            return static::highlightString($originalString, $this->search);
+        }
+    }
+
+    /* Utility function for applying highlighting to given string */
+    public static function highlightString(string $originalString, string $searchingForThisSubstring)
+    {
+        $searchStringNicelyHighlightedWithHtml = view(
+            'datatables::highlight',
+            ['slot' => $searchingForThisSubstring]
+        )->render();
+        $stringWithHighlightedSubstring = str_ireplace(
+            $searchingForThisSubstring,
+            $searchStringNicelyHighlightedWithHtml,
+            $originalString
+        );
+        return $stringWithHighlightedSubstring;
     }
 
     public function highlight($value, $string)


### PR DESCRIPTION
This adds a configuration option to stop highlighting. If it doesn't exist (like in existing configuration) the behavior won't change, and it defaults to existing behavior, but if set to true, the highlighting won't automatically be applied.
The method `highlightStringWithCurrentSearchTerm`  also reproduces the highlight logic it possible them highlight from your own callbacks. The highlight logic is completly reproduced simply because the existing highlight methods seems tightly couple with other flow in class.

(FYI: My first pull request, like ever)

Primary usage... (and meant to address https://github.com/MedicOneSystems/livewire-datatables/issues/73)

```
# in /config/livewire-datatables.php
<?php
return [
    'suppress_search_highlights' => true,  // please don't automatically highlight
];
```

```
# in /Http/Livewire/UsersTable.php (or whateverTable.php)
public function columns()
    {
        $me = $this;
        return [
 ...
        Column::Callback(
                'email',
                function (string $value) use ($me): string {
                    $maybeHighlightedValue = $me->highlightStringWithCurrentSearchTerm($value);
                    return "<a href='mailto:$value'>$maybeHighlightedValue</a>";
                })
                ->searchable()
            ,
```
