### PR TITLE
Update LivewireDatatable.php

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -375,7 +375,7 @@ class LivewireDatatable extends Component
                 break;
 
              default:
-                return $dbTable == "pgsql"
+                return $dbTable == 'pgsql'
                 ? new Expression('"'.$column['name'].'"')
                 : new Expression('`'.$column['name'].'`');
                 break;

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -355,6 +355,7 @@ class LivewireDatatable extends Component
     public function getSortString()
     {
         $column = $this->freshColumns[$this->sort];
+        $dbTable = env('DB_CONNECTION');
 
         switch (true) {
             case $column['sort']:
@@ -373,8 +374,10 @@ class LivewireDatatable extends Component
                 return Str::before($column['select'], ' AS ');
                 break;
 
-            default:
-                return new Expression('`'.$column['name'].'`');
+             default:
+                return $dbTable == "pgsql"
+                ? new Expression('"'.$column['name'].'"')
+                : new Expression('`'.$column['name'].'`');
                 break;
         }
     }


### PR DESCRIPTION
Using PostGre database I was getting the following error:
 
`SQLSTATE[42883]: Undefined function: 7 ERROR: operator does not exist: ` bigint LINE 1: ...ated_at" as "created_at" from "contacts" order by \`id\` desc ... ^ HINT: No operator matches the given name and argument type. You might need to add an explicit type cast. (SQL: select "contacts"."id" as "id", "contacts"."name" as "name", "contacts"."email" as "email", "contacts"."body" as "body", "contacts"."created_at" as "created_at" from "contacts" order by \`id\` desc limit 10 offset 0) `
 
PostGre seems to have a problem with \` id \`; more specifically the back ticks ' ` '. I changed the default part of getSortString() in LivewireDatatable.php so that it checks the DB_CONNECTION environment variable, and delivers the appropriate charracter.