### PR TITLE
selective columns export

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -26,6 +26,7 @@ class Column
     public $additionalSelects = [];
     public $filterView;
     public $align = 'left';
+    public $exportable = true;
 
     public static function name($name)
     {
@@ -243,6 +244,13 @@ class Column
     public function setType($type)
     {
         $this->type = $type;
+
+        return $this;
+    }
+
+    public function notExportable()
+    {
+        $this->exportable = false;
 
         return $this;
     }

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -100,6 +100,7 @@ class LivewireDatatable extends Component
                 'align',
                 'type',
                 'filterable',
+                'exportable',
                 'filterview',
                 'name',
             ])->toArray();
@@ -1001,7 +1002,19 @@ class LivewireDatatable extends Component
     {
         $this->forgetComputed();
 
-        return Excel::download(new DatatableExport($this->getQuery()->get()), 'DatatableExport.xlsx');
+        return Excel::download(new DatatableExport(
+            $this->getQuery()->select($this->getExportableFields())->get()),
+            'DatatableExport.xlsx'
+        );
+    }
+
+    public function getExportableFields()
+    {
+        $exportableFields = array_filter($this->columns, function ($column) {
+            return $column['exportable'];
+        });
+
+        return collect($exportableFields)->pluck('name')->toArray();
     }
 
     public function getQuery()


### PR DESCRIPTION
This pull request address #56 

All columns are exportable by default, in this way we have retro compatibility, old tables will continue to work as before.

A column can be excluded from export with the new function `notExportable()`:
```php
...
    Column::name('name')
        ->defaultSort('asc')
        ->searchable()
        ->filterable()
        ->notExportable()
...
```
