### PR TITLE
Add model_namespace to config

### DIFF
--- a/config/livewire-datatables.php
+++ b/config/livewire-datatables.php
@@ -4,4 +4,5 @@ return [
     'default_time_format' => 'H:i',
     'default_date_format' => 'd/m/Y',
     'suppress_search_highlights' => false, // When searching, don't highlight matching search results when set to true
+    'model_namespace' => 'App',
 ];


### PR DESCRIPTION
I went source diving and found this option can be used in the config, so I think it would be easier for users to see the default in the config so they know they can easily change it.

When I didn't see it in the config, I thought I would need to add this functionality and then PR the whole functionality, but it's already there. 👍  I just think it's easier for users to see it in the config file.