### PR TITLE
fix removing all text filters if the key is 0

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -526,7 +526,7 @@ class LivewireDatatable extends Component
 
     public function removeTextFilter($column, $key = null)
     {
-        if ($key) {
+        if (isset($key)) {
             unset($this->activeTextFilters[$column][$key]);
             if (count($this->activeTextFilters[$column]) < 1) {
                 unset($this->activeTextFilters[$column]);


### PR DESCRIPTION
This change fixes the problem of removing all text filters if you click to remove the first one only.
