### PR TITLE
Make per-page menu and per-page default configurable

### DIFF
--- a/config/livewire-datatables.php
+++ b/config/livewire-datatables.php
@@ -4,4 +4,6 @@ return [
     'default_time_format' => 'H:i',
     'default_date_format' => 'd/m/Y',
     'suppress_search_highlights' => false, // When searching, don't highlight matching search results when set to true
+    'per_page_options' => [ 10, 25, 50, 100 ],
+    'default_per_page' => 10,
 ];

--- a/config/livewire-datatables.php
+++ b/config/livewire-datatables.php
@@ -4,6 +4,6 @@ return [
     'default_time_format' => 'H:i',
     'default_date_format' => 'd/m/Y',
     'suppress_search_highlights' => false, // When searching, don't highlight matching search results when set to true
-    'per_page_options' => [ 10, 25, 50, 100 ],
+    'per_page_options' => [10, 25, 50, 100],
     'default_per_page' => 10,
 ];

--- a/resources/views/livewire/datatables/datatable.blade.php
+++ b/resources/views/livewire/datatables/datatable.blade.php
@@ -136,10 +136,9 @@
                     @if(count($this->results))
                         <div class="my-2 sm:my-0 flex items-center">
                             <select name="perPage" class="mt-1 form-select block w-full pl-3 pr-10 py-2 text-base leading-6 border-gray-300 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5" wire:model="perPage">
-                                <option value="10">10</option>
-                                <option value="25">25</option>
-                                <option value="50">50</option>
-                                <option value="100">100</option>
+                                @foreach(config('livewire-datatables.per_page_options', [ 10, 25, 50, 100 ]) as $per_page_option)
+                                    <option value="{{ $per_page_option }}">{{ $per_page_option }}</option>
+                                @endforeach
                                 <option value="99999999">{{__('All')}}</option>
                             </select>
                         </div>

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -75,7 +75,7 @@ class LivewireDatatable extends Component
         $afterTableSlot = false,
         $params = []
     ) {
-        foreach (['model', 'include', 'exclude', 'hide', 'dates', 'times', 'searchable', 'sort', 'hideHeader', 'hidePagination', 'perPage', 'exportable', 'hideable', 'beforeTableSlot', 'afterTableSlot'] as $property) {
+        foreach (['model', 'include', 'exclude', 'hide', 'dates', 'times', 'searchable', 'sort', 'hideHeader', 'hidePagination', 'exportable', 'hideable', 'beforeTableSlot', 'afterTableSlot'] as $property) {
             $this->$property = $this->$property ?? $$property;
         }
 
@@ -84,6 +84,8 @@ class LivewireDatatable extends Component
         $this->columns = $this->getViewColumns();
 
         $this->initialiseSort();
+
+        $this->perPage = config('livewire-datatables.default_per_page', 10);
     }
 
     public function columns()


### PR DESCRIPTION
This is to make per-page menu and per-page default configurable by adding them to the config file and then using those values instead of the hard-coded values.  The config() calls default to the previously hard-coded values, so behavior won't change if the config options are missing (i.e. it won't break anything if someone updates the component and view but retains their previous config file).