### PR TITLE
Fix orderBy quotation errors for SQL server

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -358,7 +358,12 @@ class LivewireDatatable extends Component
     public function getSortString()
     {
         $column = $this->freshColumns[$this->sort];
-        $dbTable = env('DB_CONNECTION');
+        
+        // Read the $connection property off the model (this allows multiple DBMS usage per model)
+        $dbTable = config(
+            "database.connections." . optional($this->modelInstance)->getConnectionName() . ".driver",
+            config('database.default'),
+        );
 
         switch (true) {
             case $column['sort']:
@@ -378,9 +383,9 @@ class LivewireDatatable extends Component
                 break;
 
              default:
-                return $dbTable == 'pgsql'
-                ? new Expression('"'.$column['name'].'"')
-                : new Expression('`'.$column['name'].'`');
+                return $dbTable == 'pgsql' || $dbTable == 'sqlsrv'
+                    ? new Expression('"'.$column['name'].'"')
+                    : new Expression('`'.$column['name'].'`');
                 break;
         }
     }

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -358,10 +358,10 @@ class LivewireDatatable extends Component
     public function getSortString()
     {
         $column = $this->freshColumns[$this->sort];
-        
+
         // Read the $connection property off the model (this allows multiple DBMS usage per model)
         $dbTable = config(
-            "database.connections." . optional($this->modelInstance)->getConnectionName() . ".driver",
+            "database.connections.". optional($this->modelInstance)->getConnectionName() .".driver",
             config('database.default'),
         );
 


### PR DESCRIPTION
- The `env` helper will return null if the config is cached, so it's better to default directly to the `config` helper instead.
- Fixes #104 and adds support for multiple database management systems per model (so you can use multiple database connections without being forced to use only one).