### PR TITLE
Add over-ridden aggregates support in filters

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -471,7 +471,7 @@ class LivewireDatatable extends Component
 
     public function doNumberFilterEnd($index, $end)
     {
-        $this->activeNumberFilters[$index]['end'] = $end ? (int) $end : null;
+        $this->activeNumberFilters[$index]['end'] = ($end !== '') ? (int) $end : null;
         $this->clearEmptyNumberFilter($index);
         $this->page = 1;
     }
@@ -683,9 +683,10 @@ class LivewireDatatable extends Component
 
     public function columnAggregateType($column)
     {
+        $custom_aggregate = Str::after(explode('.', $column['name'])[1], ':');
         return $column['type'] === 'string'
             ? 'group_concat'
-            : 'count';
+            : $custom_aggregate ?? 'count';
     }
 
     public function buildDatabaseQuery($export = false)

--- a/src/LivewireDatatablesServiceProvider.php
+++ b/src/LivewireDatatablesServiceProvider.php
@@ -141,7 +141,7 @@ class LivewireDatatablesServiceProvider extends ServiceProvider
         Relation::macro('getRelationExistenceAggregatesQuery', function (EloquentBuilder $query, EloquentBuilder $parentQuery, $aggregate, $column) {
             $expression = $aggregate === 'group_concat'
                 ? new Expression($aggregate."(distinct {$column} separator ', ')")
-                : new Expression($aggregate."({$column})");
+                : new Expression("COALESCE(".$aggregate."({$column}),0)");
 
             return $this->getRelationExistenceQuery(
                 $query,


### PR DESCRIPTION
If we specify a custom aggregate (max, avg, min, ...) use this aggregate for filtering data in place of 'count' if the Column is not a string column.
Also fix filtering when null values are returned with aggregates (use COALESCE for Expression) and allow to put 0 in max value for number filtering

The patch fixes issues #178 and #92 