### PR TITLE
Fix issue with coalescing non-string like columns to empty string

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -179,7 +179,7 @@ class LivewireDatatable extends Component
         return $selects->count() > 1
             ? new Expression("CONCAT_WS('" . static::SEPARATOR . "' ," .
                 collect($selects)->map(function ($select) {
-                    return "COALESCE($select, '')";
+                    return "COALESCE($select, NULL)";
                 })->join(', ') . ')')
             : $selects->first();
     }


### PR DESCRIPTION
Postgres does not allow you to coalesce a non-string like column to empty string. Tested with int, bigint, boolean as well as varchar and text.