### PR TITLE
Fixed typo: Updated variable use

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -540,7 +540,7 @@ class LivewireDatatable extends Component
         $filters = session()->get($this->sessionStorageKey() . $this->name . '_filter');
 
         $this->activeBooleanFilters = $filters['boolean'] ?? [];
-        $this->activeSelect = $filters['select'] ?? [];
+        $this->activeSelectFilters = $filters['select'] ?? [];
         $this->activeTextFilters = $filters['text'] ?? [];
         $this->activeDateFilters = $filters['date'] ?? [];
         $this->activeTimeFilters = $filters['time'] ?? [];


### PR DESCRIPTION
Updated usage of '$this->activeSelect' to '$this->activeSelectFilters'.

Select filters now persist properly.