### PR TITLE
Mass action support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 - Filter using booleans, times, dates, selects or free text
 - Create complex combined filters using the [complex query builder](#complex-query-builder)
 - Show / hide columns
+- Column groups
+- Mass Action (Bulk) Support
 
 ## [Live Demo App](https://livewire-datatables.com)
 
@@ -18,7 +20,7 @@
 ![screenshot](resources/images/screenshot.png "Screenshot")
 
 ## Requirements
-- [Laravel 7](https://laravel.com/docs/7.x)
+- [Laravel 7, 8 or 9](https://laravel.com/docs/9.x)
 - [Livewire](https://laravel-livewire.com/)
 - [Tailwind](https://tailwindcss.com/)
 - [Alpine JS](https://github.com/alpinejs/alpine)
@@ -52,7 +54,7 @@ somewhere in your CSS
 ```html
 ...
 
-<livewire:datatable model="App\User" name="all-my-users" />
+<livewire:datatable model="App\User" />
 
 ...
 ```
@@ -62,13 +64,10 @@ somewhere in your CSS
 ```html
 <livewire:datatable
     model="App\User"
-    name="users"
     include="id, name, dob, created_at"
     dates="dob"
 />
 ```
-
-- *Attention*: Please note that having multiple datatables on the same page _or_ more than one datatable of the same type on different pages needs to have a unique `name` attribute assigned to each one so they do not conflict with each other as in the example above.
 
 ### Props
 | Property | Arguments | Result | Example |
@@ -160,7 +159,10 @@ class ComplexDemoTable extends LivewireDatatable
 
             (new LabelColumn())
                 ->label('My custom heading')
-                ->content('This fixed string appears in every row')
+                ->content('This fixed string appears in every row'),
+
+            NumberColumn::name('dollars_spent')
+                ->enableSummary(),
         ];
     }
 }
@@ -238,6 +240,50 @@ public function columns()
         Column::name('planets.name')
             ->group('group2')
             ->label('Planet'),
+```
+
+### Summary row
+If you need to summarize all cells of a specific column, you can use `enableSummary()`:
+
+```php
+public function columns()
+{
+    return [
+        Column::name('dollars_spent')
+            ->label('Expenses in Dollar')
+            ->enableSummary(),
+
+        Column::name('euro_spent')
+            ->label('Expenses in Euro')
+            ->enableSummary(),
+```
+
+### Mass (Bulk) Action
+
+If you want to be able to act upon several records at once, you can use the `buildActions()` method in your Table:
+
+```php
+public function buildActions()
+    {
+        return [
+
+            Action::value('edit')->label('Edit Selected')->group('Default Options')->callback(function ($mode, $items) {
+                // $items contains an array with the primary keys of the selected items
+            }),
+
+            Action::value('update')->label('Update Selected')->group('Default Options')->callback(function ($mode, $items) {
+                // $items contains an array with the primary keys of the selected items
+            }),
+
+            Action::groupBy('Export Options', function () {
+                return [
+                    Action::value('csv')->label('Export CSV')->export('SalesOrders.csv'),
+                    Action::value('html')->label('Export HTML')->export('SalesOrders.html'),
+                    Action::value('xlsx')->label('Export XLSX')->export('SalesOrders.xlsx')->styles($this->exportStyles)->widths($this->exportWidths)
+                ];
+            }),
+        ];
+    }
 ```
 
 ### Custom column names

--- a/README.md
+++ b/README.md
@@ -291,6 +291,29 @@ public function buildActions()
     }
 ```
 
+### Mass Action Style
+
+If you only have small style adjustments to the Bulk Action Dropdown you can adjust some settings here:
+
+```php
+public function getExportStylesProperty()
+    {
+        return [
+            '1'  => ['font' => ['bold' => true]],
+            'B2' => ['font' => ['italic' => true]],
+            'C'  => ['font' => ['size' => 16]],
+        ];
+    }
+
+    public function getExportWidthsProperty()
+    {
+        return [
+            'A' => 55,
+            'B' => 45,
+        ];
+    }
+```
+
 ### Custom column names
 It is still possible to take full control over your table, you can define a ```builder``` method using whatever query you like, using your own joins, groups whatever, and then name your columns using your normal SQL syntax:
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ somewhere in your CSS
 ```html
 ...
 
-<livewire:datatable model="App\User" />
+<livewire:datatable model="App\User" name="all-users" />
 
 ...
 ```
@@ -64,10 +64,15 @@ somewhere in your CSS
 ```html
 <livewire:datatable
     model="App\User"
+    name="users"
     include="id, name, dob, created_at"
     dates="dob"
 />
 ```
+
+*Attention*: Please note that having multiple datatables on the same page _or_ more than one datatable of the same
+type on different pages needs to have a unique `name` attribute assigned to each one so they do not conflict with each
+other as in the example above.
 
 ### Props
 | Property | Arguments | Result | Example |

--- a/resources/views/livewire/datatables/datatable.blade.php
+++ b/resources/views/livewire/datatables/datatable.blade.php
@@ -39,6 +39,28 @@
                 </button>
                 @endif
 
+                @if(count($this->selectActions))
+                <div class="space-x-2">
+                    <label for="massActions">With selected:</label>
+                    <select wire:model="selectedAction" class="space-x-2 px-3 border border-green-400 rounded-md bg-white text-xs leading-4 font-medium uppercase tracking-wider focus:outline-none" id="massActions">
+                        <option value="">Choose...</option>
+                        @foreach($this->selectActions as $group => $items)
+                        @if(!$group)
+                        @foreach($items as $item)
+                        <option value="{{$item['value']}}">{{$item['label']}}</option>
+                        @endforeach
+                        @else
+                        <optgroup label="{{$group}}">
+                            @foreach($items as $item)
+                            <option value="{{$item['value']}}">{{$item['label']}}</option>
+                            @endforeach
+                        </optgroup>
+                        @endif
+                        @endforeach
+                    </select>
+                </div>
+                @endif
+
                 @if($exportable)
                 <div x-data="{ init() {
                     window.livewire.on('startDownload', link => window.open(link, '_blank'))

--- a/resources/views/livewire/datatables/datatable.blade.php
+++ b/resources/views/livewire/datatables/datatable.blade.php
@@ -5,20 +5,20 @@
         </div>
     @endif
     <div class="relative">
-        <div class="flex justify-between items-center mb-1">
-            <div class="h-10 flex items-center">
+        <div class="flex items-center justify-between mb-1">
+            <div class="flex items-center h-10">
                 @if($this->searchableColumns()->count())
-                <div class="w-96 flex rounded-lg shadow-sm">
+                <div class="flex rounded-lg w-96 shadow-sm">
                     <div class="relative flex-grow focus-within:z-10">
-                        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                            <svg class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" stroke="currentColor" fill="none">
+                        <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                            <svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" stroke="currentColor" fill="none">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                             </svg>
                         </div>
-                        <input wire:model.debounce.500ms="search" class="w-full pl-10 py-3 text-sm leading-4 block rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50 focus:outline-none" placeholder="{{__('Search in')}} {{ $this->searchableColumns()->map->label->join(', ') }}" type="text" />
-                        <div class="absolute inset-y-0 right-0 pr-2 flex items-center">
+                        <input wire:model.debounce.500ms="search" class="block w-full py-3 pl-10 text-sm border-gray-300 leading-4 rounded-md shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50 focus:outline-none" placeholder="{{__('Search in')}} {{ $this->searchableColumns()->map->label->join(', ') }}" type="text" />
+                        <div class="absolute inset-y-0 right-0 flex items-center pr-2">
                             <button wire:click="$set('search', null)" class="text-gray-300 hover:text-red-600 focus:outline-none">
-                                <x-icons.x-circle class="h-5 w-5 stroke-current" />
+                                <x-icons.x-circle class="w-5 h-5 stroke-current" />
                             </button>
                         </div>
                     </div>
@@ -31,34 +31,37 @@
             @endif
 
             <div class="flex flex-wrap items-center space-x-1">
-                <x-icons.cog wire:loading class="h-9 w-9 animate-spin text-gray-400" />
+                <x-icons.cog wire:loading class="text-gray-400 h-9 w-9 animate-spin" />
 
                 @if($this->activeFilters)
-                <button wire:click="clearAllFilters" class="flex items-center space-x-2 px-3 border border-red-400 rounded-md bg-white text-red-500 text-xs leading-4 font-medium uppercase tracking-wider hover:bg-red-200 focus:outline-none"><span>{{ __('Reset') }}</span>
+                <button wire:click="clearAllFilters" class="flex items-center px-3 text-xs font-medium tracking-wider text-red-500 uppercase bg-white border border-red-400 space-x-2 rounded-md leading-4 hover:bg-red-200 focus:outline-none"><span>{{ __('Reset') }}</span>
                     <x-icons.x-circle class="m-2" />
                 </button>
                 @endif
 
                 @if(count($this->massActionsOptions))
-                <div class="flex justify-center items-center space-x-1">
-                    <label for="datatables_mass_actions">With selected:</label>
-                    <select wire:model="massActionOption" class="space-x-2 px-3 border border-green-400 rounded-md bg-white text-xs leading-4 font-medium uppercase tracking-wider focus:outline-none" id="datatables_mass_actions">
-                        <option value="">Choose...</option>
+                <div class="flex items-center justify-center space-x-1">
+                    <label for="datatables_mass_actions">{{ __('With selected') }}:</label>
+                    <select wire:model="massActionOption" class="px-3 text-xs font-medium tracking-wider uppercase bg-white border border-green-400 space-x-2 rounded-md leading-4 focus:outline-none" id="datatables_mass_actions">
+                        <option value="">{{ __('Choose...') }}</option>
                         @foreach($this->massActionsOptions as $group => $items)
-                        @if(!$group)
-                        @foreach($items as $item)
-                        <option value="{{$item['value']}}">{{$item['label']}}</option>
-                        @endforeach
-                        @else
-                        <optgroup label="{{$group}}">
-                            @foreach($items as $item)
-                            <option value="{{$item['value']}}">{{$item['label']}}</option>
-                            @endforeach
-                        </optgroup>
-                        @endif
+                            @if(!$group)
+                                @foreach($items as $item)
+                                    <option value="{{$item['value']}}">{{$item['label']}}</option>
+                                @endforeach
+                            @else
+                                <optgroup label="{{$group}}">
+                                    @foreach($items as $item)
+                                        <option value="{{$item['value']}}">{{$item['label']}}</option>
+                                    @endforeach
+                                </optgroup>
+                            @endif
                         @endforeach
                     </select>
-                    <button wire:click="massActionOptionHandler" class="flex items-center px-4 py-2 border border-green-400 rounded-md bg-white text-green-500 text-xs leading-4 font-medium uppercase tracking-wider hover:bg-green-200 focus:outline-none" type="submit" title="Submit">Go</button>
+                    <button
+                        wire:click="massActionOptionHandler"
+                        class="flex items-center px-4 py-2 text-xs font-medium tracking-wider text-green-500 uppercase bg-white border border-green-400 rounded-md leading-4 hover:bg-green-200 focus:outline-none" type="submit" title="Submit"
+                        >Go</button>
                 </div>
                 @endif
 
@@ -66,7 +69,7 @@
                 <div x-data="{ init() {
                     window.livewire.on('startDownload', link => window.open(link, '_blank'))
                 } }" x-init="init">
-                    <button wire:click="export" class="flex items-center space-x-2 px-3 border border-green-400 rounded-md bg-white text-green-500 text-xs leading-4 font-medium uppercase tracking-wider hover:bg-green-200 focus:outline-none"><span>{{ __('Export') }}</span>
+                    <button wire:click="export" class="flex items-center px-3 text-xs font-medium tracking-wider text-green-500 uppercase bg-white border border-green-400 space-x-2 rounded-md leading-4 hover:bg-green-200 focus:outline-none"><span>{{ __('Export') }}</span>
                         <x-icons.excel class="m-2" /></button>
                 </div>
                 @endif
@@ -77,7 +80,7 @@
 
                 @foreach ($columnGroups as $name => $group)
                     <button wire:click="toggleGroup('{{ $name }}')"
-                        class="px-3 py-2 border border-green-400 rounded-md bg-white text-green-500 text-xs leading-4 font-medium uppercase tracking-wider hover:bg-green-200 focus:outline-none">
+                        class="px-3 py-2 text-xs font-medium tracking-wider text-green-500 uppercase bg-white border border-green-400 rounded-md leading-4 hover:bg-green-200 focus:outline-none">
                         <span class="flex items-center h-5">{{ isset($this->groupLabels[$name]) ? __($this->groupLabels[$name]) : __('Toggle :group', ['group' => $name]) }}</span>
                     </button>
                 @endforeach
@@ -99,7 +102,7 @@
 
         <div wire:loading.class="opacity-50" class="rounded-lg @unless($complex || $this->hidePagination) rounded-b-none @endunless shadow-lg bg-white max-w-screen overflow-x-scroll border-4 @if($this->activeFilters) border-blue-500 @else border-transparent @endif @if($complex) rounded-b-none border-b-0 @endif">
             <div>
-                <div class="table align-middle min-w-full">
+                <div class="table min-w-full align-middle">
                     @unless($this->hideHeader)
                     <div class="table-row divide-x divide-gray-200">
                         @foreach($this->columns as $index => $column)
@@ -107,7 +110,7 @@
                                 @include('datatables::header-inline-hide', ['column' => $column, 'sort' => $sort])
                             @elseif($column['type'] === 'checkbox')
                                 @unless($column['hidden'])
-                                    <div class=" table-cell h-12 w-32 py-4 flex justify-center overflow-hidden align-top px-6 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider focus:outline-none">
+                                    <div class="flex justify-center table-cell w-32 h-12 px-6 py-4 overflow-hidden text-xs font-medium tracking-wider text-left text-gray-500 uppercase align-top border-b border-gray-200 bg-gray-50 leading-4 focus:outline-none">
                                         <div class="px-3 py-1 rounded @if(count($selected)) bg-orange-400 @else bg-gray-200 @endif text-white text-center">
                                             {{ count($selected) }}
                                         </div>
@@ -119,17 +122,17 @@
                         @endforeach
                     </div>
 
-                    <div class="table-row divide-x divide-blue-200 bg-blue-100">
+                    <div class="table-row bg-blue-100 divide-x divide-blue-200">
                         @foreach($this->columns as $index => $column)
                             @if($column['hidden'])
                                 @if($hideable === 'inline')
                                     <div class="table-cell w-5 overflow-hidden align-top bg-blue-100"></div>
                                 @endif
                             @elseif($column['type'] === 'checkbox')
-                                <div class="overflow-hidden align-top bg-blue-100 px-6 py-5 border-b border-gray-200 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex h-full flex-col items-center space-y-2 focus:outline-none">
+                                <div class="flex flex-col items-center h-full px-6 py-5 overflow-hidden text-xs font-medium tracking-wider text-left text-gray-500 uppercase align-top bg-blue-100 border-b border-gray-200 leading-4 space-y-2 focus:outline-none">
                                     <div>SELECT ALL</div>
                                     <div>
-                                        <input type="checkbox" wire:click="toggleSelectAll" @if(count($selected) === $this->results->total()) checked @endif class="form-checkbox mt-1 h-4 w-4 text-blue-600 transition duration-150 ease-in-out" />
+                                        <input type="checkbox" wire:click="toggleSelectAll" @if(count($selected) === $this->results->total()) checked @endif class="w-4 h-4 mt-1 text-blue-600 form-checkbox transition duration-150 ease-in-out" />
                                     </div>
                                 </div>
                             @elseif($column['type'] === 'label')
@@ -183,11 +186,11 @@
 
         @unless($this->hidePagination)
             <div class="max-w-screen bg-white @unless($complex) rounded-b-lg @endunless border-4 border-t-0 border-b-0 @if($this->activeFilters) border-blue-500 @else border-transparent @endif">
-                <div class="p-2 sm:flex items-center justify-between">
+                <div class="items-center justify-between p-2 sm:flex">
                     {{-- check if there is any data --}}
                     @if(count($this->results))
-                        <div class="my-2 sm:my-0 flex items-center">
-                            <select name="perPage" class="mt-1 form-select block w-full pl-3 pr-10 py-2 text-base leading-6 border-gray-300 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5" wire:model="perPage">
+                        <div class="flex items-center my-2 sm:my-0">
+                            <select name="perPage" class="block w-full py-2 pl-3 pr-10 mt-1 text-base border-gray-300 form-select leading-6 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5" wire:model="perPage">
                                 @foreach(config('livewire-datatables.per_page_options', [ 10, 25, 50, 100 ]) as $per_page_option)
                                     <option value="{{ $per_page_option }}">{{ $per_page_option }}</option>
                                 @endforeach
@@ -200,7 +203,7 @@
                                 <span class="space-x-2">{{ $this->results->links('datatables::tailwind-simple-pagination') }}</span>
                             </div>
 
-                            <div class="hidden lg:flex justify-center">
+                            <div class="justify-center hidden lg:flex">
                                 <span>{{ $this->results->links('datatables::tailwind-pagination') }}</span>
                             </div>
                         </div>
@@ -226,5 +229,5 @@
         @include($afterTableSlot)
     </div>
     @endif
-    <span class="hidden text-sm leading-5 text-gray-900 text-left text-center text-right bg-gray-50 bg-gray-100 bg-yellow-100"></span>
+    <span class="hidden text-sm text-left text-center text-right text-gray-900 bg-gray-100 bg-yellow-100 leading-5 bg-gray-50"></span>
 </div>

--- a/resources/views/livewire/datatables/datatable.blade.php
+++ b/resources/views/livewire/datatables/datatable.blade.php
@@ -40,7 +40,7 @@
                 @endif
 
                 @if(count($this->selectActions))
-                <div class="space-x-2">
+                <div class="flex justify-center items-center space-x-1">
                     <label for="massActions">With selected:</label>
                     <select wire:model="selectedAction" class="space-x-2 px-3 border border-green-400 rounded-md bg-white text-xs leading-4 font-medium uppercase tracking-wider focus:outline-none" id="massActions">
                         <option value="">Choose...</option>
@@ -58,6 +58,7 @@
                         @endif
                         @endforeach
                     </select>
+                    <button wire:click="handleMassActions" class="flex items-center px-4 py-2 border border-green-400 rounded-md bg-white text-green-500 text-xs leading-4 font-medium uppercase tracking-wider hover:bg-green-200 focus:outline-none" type="submit" title="Submit">Go</button>
                 </div>
                 @endif
 

--- a/resources/views/livewire/datatables/datatable.blade.php
+++ b/resources/views/livewire/datatables/datatable.blade.php
@@ -39,12 +39,12 @@
                 </button>
                 @endif
 
-                @if(count($this->selectActions))
+                @if(count($this->massActionsOptions))
                 <div class="flex justify-center items-center space-x-1">
-                    <label for="massActions">With selected:</label>
-                    <select wire:model="selectedAction" class="space-x-2 px-3 border border-green-400 rounded-md bg-white text-xs leading-4 font-medium uppercase tracking-wider focus:outline-none" id="massActions">
+                    <label for="datatables_mass_actions">With selected:</label>
+                    <select wire:model="massActionOption" class="space-x-2 px-3 border border-green-400 rounded-md bg-white text-xs leading-4 font-medium uppercase tracking-wider focus:outline-none" id="datatables_mass_actions">
                         <option value="">Choose...</option>
-                        @foreach($this->selectActions as $group => $items)
+                        @foreach($this->massActionsOptions as $group => $items)
                         @if(!$group)
                         @foreach($items as $item)
                         <option value="{{$item['value']}}">{{$item['label']}}</option>
@@ -58,7 +58,7 @@
                         @endif
                         @endforeach
                     </select>
-                    <button wire:click="handleMassActions" class="flex items-center px-4 py-2 border border-green-400 rounded-md bg-white text-green-500 text-xs leading-4 font-medium uppercase tracking-wider hover:bg-green-200 focus:outline-none" type="submit" title="Submit">Go</button>
+                    <button wire:click="massActionOptionHandler" class="flex items-center px-4 py-2 border border-green-400 rounded-md bg-white text-green-500 text-xs leading-4 font-medium uppercase tracking-wider hover:bg-green-200 focus:outline-none" type="submit" title="Submit">Go</button>
                 </div>
                 @endif
 

--- a/src/Action.php
+++ b/src/Action.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Mediconesystems\LivewireDatatables;
+
+class Action
+{
+    public $value;
+    public $label;
+    public $group;
+    public $exportable = false;
+    public $exportableOptions = [];
+    public $callable;
+
+    public function __call($method, $args)
+    {
+        if (is_callable([$this, $method])) {
+            return call_user_func_array($this->$method, $args);
+        }
+    }
+
+    public static function value($value)
+    {
+        $column = new static;
+        $column->value = $value;
+
+        return $column;
+    }
+
+    public function label($label)
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    public function group($group)
+    {
+        $this->group = $group;
+
+        return $this;
+    }
+
+    public function exportable($exportable = true, $exportableOptions = [])
+    {
+        $this->exportable = $exportable;
+        $this->exportableOptions = $exportableOptions;
+
+        return $this;
+    }
+
+    public function callback($callable)
+    {
+        $this->callable = $callable;
+
+        return $this;
+    }
+}

--- a/src/Action.php
+++ b/src/Action.php
@@ -7,8 +7,11 @@ class Action
     public $value;
     public $label;
     public $group;
-    public $exportable = false;
-    public $exportableOptions = [];
+    public $isExport = false;
+    public $name;
+    public $type;
+    public $styles = [];
+    public $widths = [];
     public $callable;
 
     public function __call($method, $args)
@@ -40,7 +43,7 @@ class Action
         return $this;
     }
 
-    public static function groups($group, $actions)
+    public static function groupBy($group, $actions)
     {
         if ($actions instanceof \Closure) {
             return collect($actions())->each(function ($item) use ($group) {
@@ -49,10 +52,37 @@ class Action
         }
     }
 
-    public function exportable($exportable = true, $exportableOptions = [])
+    public function isExport($isExport = true)
     {
-        $this->exportable = $exportable;
-        $this->exportableOptions = $exportableOptions;
+        $this->isExport = $isExport;
+
+        return $this;
+    }
+
+    public function name($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function type($type)
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function styles($styles)
+    {
+        $this->styles = $styles;
+
+        return $this;
+    }
+
+    public function widths($widths)
+    {
+        $this->widths = $widths;
 
         return $this;
     }

--- a/src/Action.php
+++ b/src/Action.php
@@ -20,10 +20,10 @@ class Action
 
     public static function value($value)
     {
-        $column = new static;
-        $column->value = $value;
+        $action = new static;
+        $action->value = $value;
 
-        return $column;
+        return $action;
     }
 
     public function label($label)
@@ -33,11 +33,13 @@ class Action
         return $this;
     }
 
-    public function group($group)
+    public static function group($group, $actions)
     {
-        $this->group = $group;
-
-        return $this;
+        if ($actions instanceof \Closure) {
+            return collect($actions())->each(function ($item) use ($group) {
+                $item->group = $group;
+            });
+        }
     }
 
     public function exportable($exportable = true, $exportableOptions = [])

--- a/src/Action.php
+++ b/src/Action.php
@@ -7,9 +7,8 @@ class Action
     public $value;
     public $label;
     public $group;
+    public $fileName;
     public $isExport = false;
-    public $name;
-    public $type;
     public $styles = [];
     public $widths = [];
     public $callable;
@@ -52,23 +51,17 @@ class Action
         }
     }
 
+    public function export($fileName)
+    {
+        $this->fileName = $fileName;
+        $this->isExport();
+
+        return $this;
+    }
+
     public function isExport($isExport = true)
     {
         $this->isExport = $isExport;
-
-        return $this;
-    }
-
-    public function name($name)
-    {
-        $this->name = $name;
-
-        return $this;
-    }
-
-    public function type($type)
-    {
-        $this->type = $type;
 
         return $this;
     }

--- a/src/Action.php
+++ b/src/Action.php
@@ -33,7 +33,14 @@ class Action
         return $this;
     }
 
-    public static function group($group, $actions)
+    public function group($group)
+    {
+        $this->group = $group;
+
+        return $this;
+    }
+
+    public static function groups($group, $actions)
     {
         if ($actions instanceof \Closure) {
             return collect($actions())->each(function ($item) use ($group) {

--- a/src/Exports/DatatableExport.php
+++ b/src/Exports/DatatableExport.php
@@ -8,7 +8,6 @@ use Maatwebsite\Excel\Concerns\ShouldAutoSize;
 use Maatwebsite\Excel\Concerns\WithColumnWidths;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithStyles;
-use Maatwebsite\Excel\Excel as ExcelExport;
 use Maatwebsite\Excel\Facades\Excel;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
@@ -17,8 +16,7 @@ class DatatableExport implements FromCollection, WithHeadings, ShouldAutoSize, W
     use Exportable;
 
     public $collection;
-    public $fileName = 'DatatableExport';
-    public $fileType = 'xlsx';
+    public $fileName = 'DatatableExport.xlsx';
     public $styles = [];
     public $columnWidths = [];
 
@@ -47,18 +45,6 @@ class DatatableExport implements FromCollection, WithHeadings, ShouldAutoSize, W
     public function getFileName(): string
     {
         return $this->fileName;
-    }
-
-    public function setFileType($fileType)
-    {
-        $this->fileType = strtolower($fileType);
-
-        return $this;
-    }
-
-    public function getFileType(): string
-    {
-        return $this->fileType;
     }
 
     public function setColumnWidths($columnWidths)
@@ -95,51 +81,8 @@ class DatatableExport implements FromCollection, WithHeadings, ShouldAutoSize, W
         return $this->getStyles();
     }
 
-    public function getFileWriter($fileType)
-    {
-        switch ($fileType) {
-            case 'xlsx':
-                $writer = ExcelExport::XLSX;
-                break;
-            case 'csv':
-                $writer = ExcelExport::CSV;
-                break;
-            case 'tsv':
-                $writer = ExcelExport::TSV;
-                break;
-            case 'ods':
-                $writer = ExcelExport::ODS;
-                break;
-            case 'xls':
-                $writer = ExcelExport::XLS;
-                break;
-            case 'html':
-                $writer = ExcelExport::HTML;
-                break;
-            case 'mpdf':
-                $writer = ExcelExport::MPDF;
-                break;
-            case 'dompdf':
-                $writer = ExcelExport::DOMPDF;
-                break;
-            case 'tcpdf':
-                $writer = ExcelExport::TCPDF;
-                break;
-            default:
-                $writer = ExcelExport::XLSX;
-        }
-
-        return $writer;
-    }
-
     public function download()
     {
-        $fileName = $this->getFileName();
-        $fileType = $this->getFileType();
-
-        $writer = $this->getFileWriter($fileType);
-        $headers = ($fileType === 'csv') ? ['Content-Type' => 'text/csv'] : [];
-
-        return Excel::download($this, $fileName . '.' . $fileType, $writer, $headers);
+        return Excel::download($this, $this->getFileName());
     }
 }

--- a/src/Exports/DatatableExport.php
+++ b/src/Exports/DatatableExport.php
@@ -2,13 +2,13 @@
 
 namespace Mediconesystems\LivewireDatatables\Exports;
 
-use Maatwebsite\Excel\Excel as ExcelExport;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromCollection;
-use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\ShouldAutoSize;
 use Maatwebsite\Excel\Concerns\WithColumnWidths;
+use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithStyles;
+use Maatwebsite\Excel\Excel as ExcelExport;
 use Maatwebsite\Excel\Facades\Excel;
 
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;

--- a/src/Exports/DatatableExport.php
+++ b/src/Exports/DatatableExport.php
@@ -2,15 +2,26 @@
 
 namespace Mediconesystems\LivewireDatatables\Exports;
 
+use Maatwebsite\Excel\Excel as ExcelExport;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithColumnWidths;
+use Maatwebsite\Excel\Concerns\WithStyles;
+use Maatwebsite\Excel\Facades\Excel;
 
-class DatatableExport implements FromCollection, WithHeadings
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+class DatatableExport implements FromCollection, WithHeadings, ShouldAutoSize, WithColumnWidths, WithStyles
 {
     use Exportable;
 
     public $collection;
+    public $fileName = 'DatatableExport';
+    public $fileType = 'xlsx';
+    public $styles = [];
+    public $columnWidths = [];
 
     public function __construct($collection)
     {
@@ -25,5 +36,111 @@ class DatatableExport implements FromCollection, WithHeadings
     public function headings(): array
     {
         return array_keys((array) $this->collection->first());
+    }
+
+    public function setFileName($fileName)
+    {
+        $this->fileName = $fileName;
+
+        return $this;
+    }
+
+    public function getFileName(): string
+    {
+        return $this->fileName;
+    }
+
+    public function setFileType($fileType)
+    {
+        $this->fileType = strtolower($fileType);
+
+        return $this;
+    }
+
+    public function getFileType(): string
+    {
+        return $this->fileType;
+    }
+
+    public function setColumnWidths($columnWidths)
+    {
+        $this->columnWidths = $columnWidths;
+
+        return $this;
+    }
+
+    public function getColumnWidths(): array
+    {
+        return $this->columnWidths;
+    }
+
+    public function columnWidths(): array
+    {
+        return $this->getColumnWidths();
+    }
+
+    public function setStyles($styles)
+    {
+        $this->styles = $styles;
+
+        return $this;
+    }
+
+    public function getStyles(): array
+    {
+        return $this->styles;
+    }
+
+    public function styles(Worksheet $sheet)
+    {
+        return $this->getStyles();
+    }
+
+    public function getFileWriter($fileType)
+    {
+        switch ($fileType) {
+            case "xlsx":
+                $writer = ExcelExport::XLSX;
+                break;
+            case "csv":
+                $writer = ExcelExport::CSV;
+                break;
+            case "tsv":
+                $writer = ExcelExport::TSV;
+                break;
+            case "ods":
+                $writer = ExcelExport::ODS;
+                break;
+            case "xls":
+                $writer = ExcelExport::XLS;
+                break;
+            case "html":
+                $writer = ExcelExport::HTML;
+                break;
+            case "mpdf":
+                $writer = ExcelExport::MPDF;
+                break;
+            case "dompdf":
+                $writer = ExcelExport::DOMPDF;
+                break;
+            case "tcpdf":
+                $writer = ExcelExport::TCPDF;
+                break;
+            default:
+                $writer = ExcelExport::XLSX;
+        }
+
+        return $writer;
+    }
+
+    public function download()
+    {
+        $fileName = $this->getFileName();
+        $fileType = $this->getFileType();
+
+        $writer = $this->getFileWriter($fileType);
+        $headers = ($fileType === 'csv') ? ['Content-Type' => 'text/csv'] : [];
+
+        return Excel::download($this, $fileName . '.' . $fileType, $writer, $headers);
     }
 }

--- a/src/Exports/DatatableExport.php
+++ b/src/Exports/DatatableExport.php
@@ -99,31 +99,31 @@ class DatatableExport implements FromCollection, WithHeadings, ShouldAutoSize, W
     public function getFileWriter($fileType)
     {
         switch ($fileType) {
-            case "xlsx":
+            case 'xlsx':
                 $writer = ExcelExport::XLSX;
                 break;
-            case "csv":
+            case 'csv':
                 $writer = ExcelExport::CSV;
                 break;
-            case "tsv":
+            case 'tsv':
                 $writer = ExcelExport::TSV;
                 break;
-            case "ods":
+            case 'ods':
                 $writer = ExcelExport::ODS;
                 break;
-            case "xls":
+            case 'xls':
                 $writer = ExcelExport::XLS;
                 break;
-            case "html":
+            case 'html':
                 $writer = ExcelExport::HTML;
                 break;
-            case "mpdf":
+            case 'mpdf':
                 $writer = ExcelExport::MPDF;
                 break;
-            case "dompdf":
+            case 'dompdf':
                 $writer = ExcelExport::DOMPDF;
                 break;
-            case "tcpdf":
+            case 'tcpdf':
                 $writer = ExcelExport::TCPDF;
                 break;
             default:

--- a/src/Exports/DatatableExport.php
+++ b/src/Exports/DatatableExport.php
@@ -10,7 +10,6 @@ use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithStyles;
 use Maatwebsite\Excel\Excel as ExcelExport;
 use Maatwebsite\Excel\Facades\Excel;
-
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class DatatableExport implements FromCollection, WithHeadings, ShouldAutoSize, WithColumnWidths, WithStyles

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1488,10 +1488,6 @@ class LivewireDatatable extends Component
 
         $export = new DatatableExport($this->getExportResultsSet());
 
-        $export->setFileName('DatatableExport');
-
-        $export->setFileType('xlsx');
-
         return $export->download();
     }
 
@@ -1585,7 +1581,7 @@ class LivewireDatatable extends Component
     public function getMassActions()
     {
         return collect($this->massActions)->map(function ($action) {
-            return collect($action)->except(['callable'])->toArray();
+            return collect($action)->only(['group', 'value', 'label'])->toArray();
         })->toArray();
     }
 
@@ -1623,24 +1619,15 @@ class LivewireDatatable extends Component
 
         $collection = collect($action);
 
-        $isExport = $collection->get('isExport');
-
-        if ($isExport) {
-            $fileName = $collection->get('name');
-            $fileType = $collection->get('type');
+        if ($collection->get('isExport')) {
+            $fileName = $collection->get('fileName');
 
             $styles = $collection->get('styles');
             $widths = $collection->get('widths');
 
             $datatableExport = new DatatableExport($this->getExportResultsSet());
 
-            if ($fileName) {
-                $datatableExport->setFileName($fileName);
-            }
-
-            if ($fileType) {
-                $datatableExport->setFileType($fileType);
-            }
+            $datatableExport->setFileName($fileName);
 
             if ($styles) {
                 $datatableExport->setStyles($styles);

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1626,7 +1626,6 @@ class LivewireDatatable extends Component
         $isExport = $collection->get('isExport');
 
         if ($isExport) {
-
             $fileName = $collection->get('name');
             $fileType = $collection->get('type');
 
@@ -1656,6 +1655,7 @@ class LivewireDatatable extends Component
 
         if (! count($this->selected)) {
             $this->selectedAction = null;
+
             return;
         }
 

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1583,7 +1583,7 @@ class LivewireDatatable extends Component
 
     public function getMassActionsProperty()
     {
-        $actions = collect($this->buildActions());
+        $actions = collect($this->buildActions())->flatten();
 
         $duplicates = $actions->pluck('value')->duplicates();
 
@@ -1591,7 +1591,7 @@ class LivewireDatatable extends Component
             throw new Exception('Duplicate Action(s): ' . implode(', ', $duplicates->toArray()));
         }
 
-        return $actions->flatten()->toArray();
+        return $actions->toArray();
     }
 
     public function getSelectActionsProperty()

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1576,22 +1576,22 @@ class LivewireDatatable extends Component
 
     public function getMassActions()
     {
-        return collect($this->massActions)->flatten()->map(function ($action) {
+        return collect($this->massActions)->map(function ($action) {
             return collect($action)->except(['exportable', 'exportableOptions', 'callable'])->toArray();
         })->toArray();
     }
 
     public function getMassActionsProperty()
     {
-        $actions = $this->buildActions();
+        $actions = collect($this->buildActions());
 
-        $duplicates = collect($actions)->pluck('value')->duplicates();
+        $duplicates = $actions->pluck('value')->duplicates();
 
         if ($duplicates->count()) {
             throw new Exception('Duplicate Action(s): ' . implode(', ', $duplicates->toArray()));
         }
 
-        return $actions;
+        return $actions->flatten()->toArray();
     }
 
     public function getSelectActionsProperty()
@@ -1608,7 +1608,7 @@ class LivewireDatatable extends Component
             return;
         }
 
-        $action = collect($this->massActions)->flatten()->filter(function ($item) use ($value) {
+        $action = collect($this->massActions)->filter(function ($item) use ($value) {
             return $item->value === $value;
         })->shift();
 

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -238,7 +238,6 @@ class LivewireDatatable extends Component
 
         $this->columns = $this->getViewColumns();
         $this->actions = $this->getMassActions();
-        
         $this->initialiseSearch();
         $this->initialiseSort();
         $this->initialiseHiddenColumns();

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1576,11 +1576,11 @@ class LivewireDatatable extends Component
 
     public function getMassActions()
     {
-        return collect($this->massActions)->map(function ($action) {
-            return collect($action)->only(['value', 'label', 'group'])->toArray();
+        return collect($this->massActions)->flatten()->map(function ($action) {
+            return collect($action)->except(['exportable', 'exportableOptions', 'callable'])->toArray();
         })->toArray();
     }
-	
+
     public function getMassActionsProperty()
     {
         $actions = $this->buildActions();
@@ -1608,14 +1608,17 @@ class LivewireDatatable extends Component
             return;
         }
 
-        $action = collect($this->massActions)->filter(function($item) use ($value) {
+        $action = collect($this->massActions)->flatten()->filter(function ($item) use ($value) {
             return $item->value === $value;
         })->shift();
 
         $collection = collect($action);
 
+        // @todo -- Export with type and user defined params if any.
         if ($collection->has('exportable')) {
-            // @todo -- Export with type and user defined params if any.
+            if ($collection->has('exportableOptions')) {
+                $exportOptions = $collection->get('exportableOptions');
+            }
         }
 
         if ($collection->has('callable') && is_callable($action->callable)) {

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -237,7 +237,6 @@ class LivewireDatatable extends Component
         $this->params = $params;
 
         $this->columns = $this->getViewColumns();
-
         $this->actions = $this->getMassActions();
       
         $this->initialiseSearch();

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1581,7 +1581,7 @@ class LivewireDatatable extends Component
         // Override this method with your own method for adding classes to a cell
         return config('livewire-datatables.default_classes.cell', 'text-sm text-gray-900');
     }
-    
+
     public function getMassActions()
     {
         return collect($this->massActions)->map(function ($action) {

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -16,7 +16,6 @@ use Illuminate\Support\Str;
 use Illuminate\View\View;
 use Livewire\Component;
 use Livewire\WithPagination;
-use Maatwebsite\Excel\Facades\Excel;
 use Mediconesystems\LivewireDatatables\Column;
 use Mediconesystems\LivewireDatatables\ColumnSet;
 use Mediconesystems\LivewireDatatables\Exports\DatatableExport;
@@ -1582,6 +1581,7 @@ class LivewireDatatable extends Component
         // Override this method with your own method for adding classes to a cell
         return config('livewire-datatables.default_classes.cell', 'text-sm text-gray-900');
     }
+    
     public function getMassActions()
     {
         return collect($this->massActions)->map(function ($action) {
@@ -1611,7 +1611,7 @@ class LivewireDatatable extends Component
 
     public function handleMassActions()
     {
-        if (!$this->selectedAction) {
+        if (! $this->selectedAction) {
             return;
         }
 
@@ -1650,11 +1650,11 @@ class LivewireDatatable extends Component
             if ($widths) {
                 $datatableExport->setColumnWidths($widths);
             }
-    
+
             return $datatableExport->download();
         }
 
-        if (!count($this->selected)) {
+        if (! count($this->selected)) {
             $this->selectedAction = null;
             return;
         }

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -67,7 +67,7 @@ class LivewireDatatable extends Component
     public $persistFilters = true;
 
     public $actions;
-    public $selectedAction;
+    public $massActionOption;
 
     /**
      * @var array List your groups and the corresponding label (or translation) here.
@@ -1592,26 +1592,26 @@ class LivewireDatatable extends Component
         $duplicates = $actions->pluck('value')->duplicates();
 
         if ($duplicates->count()) {
-            throw new Exception('Duplicate Action(s): ' . implode(', ', $duplicates->toArray()));
+            throw new Exception('Duplicate Mass Action(s): ' . implode(', ', $duplicates->toArray()));
         }
 
         return $actions->toArray();
     }
 
-    public function getSelectActionsProperty()
+    public function getMassActionsOptionsProperty()
     {
         return collect($this->actions)->groupBy(function ($item) {
             return $item['group'];
         }, true);
     }
 
-    public function handleMassActions()
+    public function massActionOptionHandler()
     {
-        if (! $this->selectedAction) {
+        if (! $this->massActionOption) {
             return;
         }
 
-        $option = $this->selectedAction;
+        $option = $this->massActionOption;
 
         $action = collect($this->massActions)->filter(function ($item) use ($option) {
             return $item->value === $option;
@@ -1620,28 +1620,19 @@ class LivewireDatatable extends Component
         $collection = collect($action);
 
         if ($collection->get('isExport')) {
-            $fileName = $collection->get('fileName');
-
-            $styles = $collection->get('styles');
-            $widths = $collection->get('widths');
-
             $datatableExport = new DatatableExport($this->getExportResultsSet());
 
-            $datatableExport->setFileName($fileName);
+            $datatableExport->setFileName($collection->get('fileName'));
 
-            if ($styles) {
-                $datatableExport->setStyles($styles);
-            }
+            $datatableExport->setStyles($collection->get('styles'));
 
-            if ($widths) {
-                $datatableExport->setColumnWidths($widths);
-            }
+            $datatableExport->setColumnWidths($collection->get('widths'));
 
             return $datatableExport->download();
         }
 
         if (! count($this->selected)) {
-            $this->selectedAction = null;
+            $this->massActionOption = null;
 
             return;
         }
@@ -1650,7 +1641,7 @@ class LivewireDatatable extends Component
             $action->callable($option, $this->selected);
         }
 
-        $this->selectedAction = null;
+        $this->massActionOption = null;
         $this->selected = [];
     }
 }

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -238,7 +238,7 @@ class LivewireDatatable extends Component
 
         $this->columns = $this->getViewColumns();
         $this->actions = $this->getMassActions();
-      
+        
         $this->initialiseSearch();
         $this->initialiseSort();
         $this->initialiseHiddenColumns();


### PR DESCRIPTION
This is completely opinionated. Suggestions are welcome.

```
    public function buildActions()
    {
        return [

            Action::value('edit')->label('Edit Selected')->group('Default Options')->callback(function ($mode, $items) {
                $this->editHandler($mode, $items);
            }),

            Action::value('update')->label('Update Selected')->group('Default Options')->callback(function ($mode, $items) {
                $this->editHandler($mode, $items);
            }),

            Action::groupBy('Export Options', function () {
                return [
                    Action::value('csv')->label('Export CSV')->export('SalesOrders.csv'),
                    Action::value('html')->label('Export HTML')->export('SalesOrders.html'),
                    Action::value('xlsx')->label('Export XLSX')->export('SalesOrders.xlsx')->styles($this->exportStyles)->widths($this->exportWidths)
                ];
            }),
        ];
    }

    public function editHandler($mode, $items)
    {

    }

    public function getExportStylesProperty()
    {
        return [
            '1'  => ['font' => ['bold' => true]],
            'B2' => ['font' => ['italic' => true]],
            'C'  => ['font' => ['size' => 16]],
        ];
    }

    public function getExportWidthsProperty()
    {
        return [
            'A' => 55,
            'B' => 45,
        ];
    }
```