### PR TITLE
Rename export file

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -50,6 +50,7 @@ class LivewireDatatable extends Component
     public $times;
     public $searchable;
     public $exportable;
+    public $export_name;
     public $hideable;
     public $params;
     public $selected = [];
@@ -170,6 +171,7 @@ class LivewireDatatable extends Component
         $hidePagination = null,
         $perPage = null,
         $exportable = false,
+        $export_name = null,
         $hideable = false,
         $beforeTableSlot = false,
         $afterTableSlot = false,
@@ -1495,7 +1497,7 @@ class LivewireDatatable extends Component
             })->all();
         });
 
-        return Excel::download(new DatatableExport($results), 'DatatableExport.xlsx');
+        return Excel::download(new DatatableExport($results), $this->export_name?$this->export_name.'.xlsx':'DatatableExport.xlsx');
     }
 
     public function getQuery($export = false)

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1497,7 +1497,7 @@ class LivewireDatatable extends Component
             })->all();
         });
 
-        return Excel::download(new DatatableExport($results), $this->export_name?$this->export_name.'.xlsx':'DatatableExport.xlsx');
+        return Excel::download(new DatatableExport($results), $this->export_name ? $this->export_name . '.xlsx' : 'DatatableExport.xlsx');
     }
 
     public function getQuery($export = false)


### PR DESCRIPTION
without set export name : 
```
class DemoTable extends LivewireDatatable
{

    public $exportable = true;

   // export file name "DatatableExport.xlsx"
}
```
with set export name : 
```
class DemoTable extends LivewireDatatable
{

    public $exportable = true;
    public $export_name = 'Export Demo';

   // export file name "Export Demo.xlsx"
}
```
or
```
class DemoTable extends LivewireDatatable
{

    public $exportable = true;
    public $export_name = '';

    public function __construct()
    {
        $this->export_name = 'Export Demo ' . date('YmdHis');
    }

   // export file name "Export Demo 20211116140000.xlsx"
}
```