### PR TITLE
Move highlight call before export callback calls.

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1383,7 +1383,6 @@ class LivewireDatatable extends Component
                 if ($this->search && ! config('livewire-datatables.suppress_search_highlights') && $this->searchableColumns()->firstWhere('name', $name)) {
                     $row->$name = $this->highlight($row->$name, $this->search);
                 }
-                
                 if ($export && isset($this->export_callbacks[$name])) {
                     $values = Str::contains($value, static::SEPARATOR) ? explode(static::SEPARATOR, $value) : [$value, $row];
                     $row->$name = $this->export_callbacks[$name](...$values);

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1380,6 +1380,10 @@ class LivewireDatatable extends Component
     {
         $paginatedCollection->collect()->map(function ($row, $i) use ($export) {
             foreach ($row as $name => $value) {
+                if ($this->search && ! config('livewire-datatables.suppress_search_highlights') && $this->searchableColumns()->firstWhere('name', $name)) {
+                    $row->$name = $this->highlight($row->$name, $this->search);
+                }
+                
                 if ($export && isset($this->export_callbacks[$name])) {
                     $values = Str::contains($value, static::SEPARATOR) ? explode(static::SEPARATOR, $value) : [$value, $row];
                     $row->$name = $this->export_callbacks[$name](...$values);
@@ -1398,10 +1402,6 @@ class LivewireDatatable extends Component
                     $row->$name = $this->callbacks[$name](...explode(static::SEPARATOR, $value));
                 } elseif (isset($this->callbacks[$name]) && is_callable($this->callbacks[$name])) {
                     $row->$name = $this->callbacks[$name]($value, $row);
-                }
-
-                if ($this->search && ! config('livewire-datatables.suppress_search_highlights') && $this->searchableColumns()->firstWhere('name', $name)) {
-                    $row->$name = $this->highlight($row->$name, $this->search);
                 }
             }
 


### PR DESCRIPTION
The highlight call is currently executed after the export callback, making it impossible to strip out the highlighting markup that is added for search results. Moving the highlighting before the export callbacks resolves this.