### PR TITLE
Adds ability to sort by multiple columns (multisort)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ### Features
 - Use a model or query builder to supply data
 - Mutate and format columns using preset or custom callbacks
-- Sort data using column or computed column
+- Sort data using one or more columns or computed columns
 - Filter using booleans, times, dates, selects or free text
 - Create complex combined filters using the [complex query builder](#complex-query-builder)
 - Show / hide columns
@@ -77,7 +77,8 @@ somewhere in your CSS
 |**dates**|*String\|Array* of column definitions [ and optional format in \| delimited string]|column values are formatted as per the default date format, or format can be included in string with \| separator | ```:dates="['dob\|lS F y', 'created_at']"```|
 |**times**|*String\|Array* of column definitions [optional format in \| delimited string]|column values are formatted as per the default time format, or format can be included in string with \| separator | ```'bedtime\|g:i A'```|
 |**searchable**|*String\|Array* of column names | Defines columns to be included in global search | ```searchable="name, email"```|
-|**sort**|*String* of column definition [and optional 'asc' or 'desc' (default: 'desc') in \| delimited string]|Specifies the column and direction for initial table sort. Default is column 0 descending | ```sort="name\|asc"```|
+|**sort**|*String, int or array* of column(s) definition [and optional 'asc' or 'desc' (default: 'desc') Specifies the column and direction for initial table sort. Default is column 0 descending | ```sort="name\|asc"```|
+|**multisort**|*Boolean default: false*|When set to true, sort is done using multiple columns.
 |**hide-header**|*Boolean* default: *false*|The top row of the table including the column titles is removed if this is ```true```| |
 |**hide-pagination**|*Boolean* default: *false*|Pagination controls are removed if this is ```true```| |
 |**per-page**|*Integer* default: 10|Number of rows per page| ```per-page="20"``` |
@@ -87,6 +88,22 @@ somewhere in your CSS
 |**afterTableSlot**| _String_ |blade view to be included immediately after the table in the component, which can therefore access public properties| [demo](https://livewire-datatables.com/complex) |
 ---
 
+## Sorting by multiple columns (multisort)
+![Multisort Demo](http://g.recordit.co/u5nCxb7hTp.gif "Multisort Demo")
+### Enable multisort
+Multisort is disabled by default. To enable it set ```multisort = true``` on your ```livewire-datatable``` component.
+```html
+...
+
+<livewire:datatable model="App\User" multisort=true />
+
+...
+```
+### How does it work?
+There's 3 possible states a column can have when multisort is enabled. Clicking on a column will advance its state.
+- 1st click: column added to the sort with direction `desc`.
+- 2nd click: direction changes to `asc`.
+- 3rd click: column removed from sort. 
 
 ## Component Syntax
 

--- a/resources/views/livewire/datatables/datatable.blade.php
+++ b/resources/views/livewire/datatables/datatable.blade.php
@@ -6,6 +6,14 @@
     @endif
     <div class="relative">
         <div class="flex justify-between items-center mb-1">
+            @if(isset($this->multisort) && $this->multisort === true && count($this->sort) > 1)
+                <button wire:loading.class="opacity-50" wire:click="forgetSortSession"
+                        class="px-3 py-2 border border-blue-400 rounded-md bg-white text-blue-500 text-xs leading-4 font-medium uppercase tracking-wider hover:bg-blue-200 focus:outline-none">
+                    <div class="flex items-center h-2">
+                        {{ __('Reset Columns Sort')}}
+                    </div>
+                </button>
+            @endif
             <div class="h-10 flex items-center">
                 @if($this->searchableColumns()->count())
                 <div class="w-96 flex rounded-lg shadow-sm">

--- a/resources/views/livewire/datatables/header-no-hide.blade.php
+++ b/resources/views/livewire/datatables/header-no-hide.blade.php
@@ -1,22 +1,44 @@
 @unless($column['hidden'])
-<div class="relative table-cell h-12 overflow-hidden align-top" @if (isset($column['width']))style="width:{{ $column['width'] }}"@endif>
-    @if($column['unsortable'])
-        <div class="w-full h-full px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex items-center focus:outline-none @if($column['align'] === 'right') justify-end @elseif($column['align'] === 'center') justify-center @endif">
-            <span class="inline ">{{ str_replace('_', ' ', $column['label']) }}</span>
-        </div>
-    @else
-        <button wire:click="sort('{{ $index }}')" class="w-full h-full px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex items-center focus:outline-none @if($column['align'] === 'right') justify-end @elseif($column['align'] === 'center') justify-center @endif">
-            <span class="inline ">{{ str_replace('_', ' ', $column['label']) }}</span>
-            <span class="inline text-xs text-blue-400">
-                @if($sort === $index)
-                    @if($direction)
-                        <x-icons.chevron-up wire:loading.remove class="h-6 w-6 text-green-600 stroke-current" />
-                    @else
-                        <x-icons.chevron-down wire:loading.remove class="h-6 w-6 text-green-600 stroke-current" />
+    <div class="relative table-cell h-12 overflow-hidden align-top"
+         @if (isset($column['width']))style="width:{{ $column['width'] }}"@endif>
+        @if($column['unsortable'])
+            <div
+                class="w-full h-full px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex items-center focus:outline-none @if($column['align'] === 'right') justify-end @elseif($column['align'] === 'center') justify-center @endif">
+                <span class="inline ">{{ str_replace('_', ' ', $column['label']) }}</span>
+            </div>
+        @else
+            <button wire:click="sort('{{ $index }}')"
+                    class="w-full h-full px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex items-center focus:outline-none @if($column['align'] === 'right') justify-end @elseif($column['align'] === 'center') justify-center @endif">
+                <span class="inline ">{{ str_replace('_', ' ', $column['label']) }}</span>
+                <span class="inline flex text-xs text-blue-400">
+                    @if(! isset($this->multisort) || $this->multisort === false)
+                        @if(isset($sort[0]) && $this->getIndexFromValue($sort[0]) == $index && ($direction = $this->getColumnDirection($sort[0])))
+                            @if($direction === 'asc')
+                                <x-icons.chevron-up wire:loading.remove class="h-6 w-6 text-green-600 stroke-current"/>
+                            @endif
+                            @if($direction === 'desc')
+                                <x-icons.chevron-down wire:loading.remove
+                                                      class="h-6 w-6 text-green-600 stroke-current"/>
+                            @endif
+                        @endif
+                    @elseif($this->multisort === true)
+                        @foreach($sort as $key => $value)
+                            @if($this->getIndexFromValue($value) == $index && ($direction = $this->getColumnDirection($value)))
+                                @if($direction === 'asc')
+                                    <x-icons.chevron-up wire:loading.remove
+                                                        class="h-6 w-6 text-green-600 stroke-current"/>
+                                    <div>{{$key + 1}}</div>
+                                @endif
+                                @if($direction === 'desc')
+                                    <x-icons.chevron-down wire:loading.remove
+                                                          class="h-6 w-6 text-green-600 stroke-current"/>
+                                    <div>{{$key + 1}}</div>
+                                @endif
+                            @endif
+                        @endforeach
                     @endif
-                @endif
             </span>
-        </button>
-    @endif
-</div>
+            </button>
+        @endif
+    </div>
 @endif

--- a/src/Column.php
+++ b/src/Column.php
@@ -120,7 +120,7 @@ class Column
         return $this;
     }
 
-    public function defaultSort($direction = true)
+    public function defaultSort(?string $direction = 'desc')
     {
         $this->defaultSort = $direction;
 

--- a/src/ColumnSet.php
+++ b/src/ColumnSet.php
@@ -135,8 +135,15 @@ class ColumnSet
 
     public function sort($sort)
     {
-        if ($sort && $column = $this->columns->first(function ($column) use ($sort) {
-            return Str::after($column->name, '.') === Str::before($sort, '|');
+        if (is_array($sort)) {
+            foreach ($sort as $arg) {
+                $this->sort($arg);
+            }
+            return $this;
+        }
+
+        if ($sort && $column = $this->columns->first(function ($column, $key) use ($sort) {
+            return Str::after($column->name, '.') === ($sort = Str::before($sort, '|')) || $sort === $key;
         })) {
             $column->defaultSort(Str::of($sort)->contains('|') ? Str::after($sort, '|') : null);
         }

--- a/tests/LivewireDatatableClassTest.php
+++ b/tests/LivewireDatatableClassTest.php
@@ -40,8 +40,7 @@ class LivewireDatatableClassTest extends TestCase
 
         $this->assertIsArray($subject->columns);
 
-        $this->assertEquals(0, $subject->sort);
-        $this->assertFalse($subject->direction);
+        $this->assertEquals(['0|desc'], $subject->sort);
     }
 
     /** @test */
@@ -60,7 +59,7 @@ class LivewireDatatableClassTest extends TestCase
     }
 
     /** @test */
-    public function it_can_order_results()
+    public function it_can_order_results_for_a_column()
     {
         factory(DummyModel::class)->create(['subject' => 'Beet growing for noobs']);
         factory(DummyModel::class)->create(['subject' => 'Advanced beet growing']);
@@ -71,11 +70,77 @@ class LivewireDatatableClassTest extends TestCase
         $this->assertEquals('Advanced beet growing', $subject->results->getCollection()[1]->subject);
 
         $subject->forgetComputed();
-        $subject->sort = 1;
-        $subject->direction = true;
+        $subject->sort = ['1|asc'];
 
         $this->assertEquals('Advanced beet growing', $subject->results->getCollection()[0]->subject);
         $this->assertEquals('Beet growing for noobs', $subject->results->getCollection()[1]->subject);
+    }
+
+    /** @test */
+    public function it_can_order_results_for_multiple_columns_using_column_index()
+    {
+        factory(DummyModel::class)->create(['subject' => 'Beet growing for noobs', 'category' => 'A']);
+        factory(DummyModel::class)->create(['subject' => 'Advanced beet growing', 'category' => 'A']);
+        factory(DummyModel::class)->create(['subject' => 'Advanced beet growing', 'category' => 'B']);
+        factory(DummyModel::class)->create(['subject' => 'Beet growing for noobs', 'category' => 'B']);
+
+        $subject = new DummyTable(1);
+
+        $this->assertEquals(['Beet growing for noobs', 'A'], [$subject->results->getCollection()[0]->subject, $subject->results->getCollection()[0]->category]);
+        $this->assertEquals(['Advanced beet growing', 'A'], [$subject->results->getCollection()[1]->subject, $subject->results->getCollection()[1]->category]);
+        $this->assertEquals(['Advanced beet growing', 'B'], [$subject->results->getCollection()[2]->subject, $subject->results->getCollection()[2]->category]);
+        $this->assertEquals(['Beet growing for noobs', 'B'], [$subject->results->getCollection()[3]->subject, $subject->results->getCollection()[3]->category]);
+
+        $subject->forgetComputed();
+        $subject->multisort = true;
+        $subject->sort = ["1|asc", "2|desc"];
+
+        $this->assertEquals(['Advanced beet growing', 'B'], [$subject->results->getCollection()[0]->subject, $subject->results->getCollection()[0]->category]);
+        $this->assertEquals(['Advanced beet growing', 'A'], [$subject->results->getCollection()[1]->subject, $subject->results->getCollection()[1]->category]);
+        $this->assertEquals(['Beet growing for noobs', 'B'], [$subject->results->getCollection()[2]->subject, $subject->results->getCollection()[2]->category]);
+        $this->assertEquals(['Beet growing for noobs', 'A'], [$subject->results->getCollection()[3]->subject, $subject->results->getCollection()[3]->category]);
+
+        $subject->forgetComputed();
+        $subject->sort = ["1|asc", "2|asc"];
+
+        $this->assertEquals(['Advanced beet growing', 'A'], [$subject->results->getCollection()[0]->subject, $subject->results->getCollection()[0]->category]);
+        $this->assertEquals(['Advanced beet growing', 'B'], [$subject->results->getCollection()[1]->subject, $subject->results->getCollection()[1]->category]);
+        $this->assertEquals(['Beet growing for noobs', 'A'], [$subject->results->getCollection()[2]->subject, $subject->results->getCollection()[2]->category]);
+        $this->assertEquals(['Beet growing for noobs', 'B'], [$subject->results->getCollection()[3]->subject, $subject->results->getCollection()[3]->category]);
+
+    }
+
+    /** @test */
+    public function it_can_order_results_for_multiple_columns_using_column_name()
+    {
+        factory(DummyModel::class)->create(['subject' => 'Beet growing for noobs', 'category' => 'A']);
+        factory(DummyModel::class)->create(['subject' => 'Advanced beet growing', 'category' => 'A']);
+        factory(DummyModel::class)->create(['subject' => 'Advanced beet growing', 'category' => 'B']);
+        factory(DummyModel::class)->create(['subject' => 'Beet growing for noobs', 'category' => 'B']);
+
+        $subject = new DummyTable(1);
+
+        $this->assertEquals(['Beet growing for noobs', 'A'], [$subject->results->getCollection()[0]->subject, $subject->results->getCollection()[0]->category]);
+        $this->assertEquals(['Advanced beet growing', 'A'], [$subject->results->getCollection()[1]->subject, $subject->results->getCollection()[1]->category]);
+        $this->assertEquals(['Advanced beet growing', 'B'], [$subject->results->getCollection()[2]->subject, $subject->results->getCollection()[2]->category]);
+        $this->assertEquals(['Beet growing for noobs', 'B'], [$subject->results->getCollection()[3]->subject, $subject->results->getCollection()[3]->category]);
+
+        $subject->forgetComputed();
+        $subject->multisort = true;
+        $subject->sort = ["subject|asc", "category|desc"];
+
+        $this->assertEquals(['Advanced beet growing', 'B'], [$subject->results->getCollection()[0]->subject, $subject->results->getCollection()[0]->category]);
+        $this->assertEquals(['Advanced beet growing', 'A'], [$subject->results->getCollection()[1]->subject, $subject->results->getCollection()[1]->category]);
+        $this->assertEquals(['Beet growing for noobs', 'B'], [$subject->results->getCollection()[2]->subject, $subject->results->getCollection()[2]->category]);
+        $this->assertEquals(['Beet growing for noobs', 'A'], [$subject->results->getCollection()[3]->subject, $subject->results->getCollection()[3]->category]);
+
+        $subject->forgetComputed();
+        $subject->sort = ["subject|asc", "category|asc"];
+
+        $this->assertEquals(['Advanced beet growing', 'A'], [$subject->results->getCollection()[0]->subject, $subject->results->getCollection()[0]->category]);
+        $this->assertEquals(['Advanced beet growing', 'B'], [$subject->results->getCollection()[1]->subject, $subject->results->getCollection()[1]->category]);
+        $this->assertEquals(['Beet growing for noobs', 'A'], [$subject->results->getCollection()[2]->subject, $subject->results->getCollection()[2]->category]);
+        $this->assertEquals(['Beet growing for noobs', 'B'], [$subject->results->getCollection()[3]->subject, $subject->results->getCollection()[3]->category]);
     }
 
     /** @test */

--- a/tests/LivewireDatatableMultisortableQueryBuilderTest.php
+++ b/tests/LivewireDatatableMultisortableQueryBuilderTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Mediconesystems\LivewireDatatables\Tests;
+
+use Illuminate\Contracts\Session\Session;
+use Mediconesystems\LivewireDatatables\Http\Livewire\LivewireDatatable;
+use Mediconesystems\LivewireDatatables\Tests\Models\DummyBelongsToManyModel;
+use Mediconesystems\LivewireDatatables\Tests\Models\DummyHasManyModel;
+use Mediconesystems\LivewireDatatables\Tests\Models\DummyHasOneModel;
+use Mediconesystems\LivewireDatatables\Tests\Models\DummyModel;
+
+class LivewireDatatableMultisortQueryBuilderTest extends TestCase
+{
+    /** @test */
+    public function it_toggles_sort_status_on_each_sort_trigger()
+    {
+        factory(DummyModel::class)->create();
+
+        $subject = new LivewireDatatable(1);
+        $subject->multisort = true;
+        $subject->mount(DummyModel::class, ['id', 'subject', 'category']);
+
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
+
+        $subject->sort(0);
+
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` asc', $subject->getQuery()->toSql());
+
+        $subject->sort(0);
+
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models"', $subject->getQuery()->toSql());
+
+        $subject->sort(0);
+
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
+
+    }
+
+    /** @test */
+    public function it_creates_a_multisort_query_builder_for_base_columns()
+    {
+        factory(DummyModel::class)->create();
+        $subject = new LivewireDatatable(1);
+        $subject->multisort = true;
+        $subject->mount(DummyModel::class, ['id', 'subject', 'category']);
+
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc, `subject` desc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc, `subject` asc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
+
+        $subject->sort(2);
+
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc, `category` desc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_models"."subject" as "subject", "dummy_models"."category" as "category" from "dummy_models" order by `id` desc, `category` desc, `subject` desc', $subject->getQuery()->toSql());
+    }
+
+    /** @test */
+    public function it_creates_a_multisort_query_builder_for_has_one_relation_columns()
+    {
+        factory(DummyModel::class)->create()->dummy_has_one()->save(factory(DummyHasOneModel::class)->make());
+
+        $subject = new LivewireDatatable(1);
+        $subject->multisort = true;
+        $subject->mount(DummyModel::class, ['id', 'dummy_has_one.name', 'dummy_has_one.category']);
+
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_has_one_models"."name" as "dummy_has_one.name", "dummy_has_one_models"."category" as "dummy_has_one.category" from "dummy_models" left join "dummy_has_one_models" on "dummy_has_one_models"."dummy_model_id" = "dummy_models"."id" order by `id` desc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+        $subject->forgetComputed();
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_has_one_models"."name" as "dummy_has_one.name", "dummy_has_one_models"."category" as "dummy_has_one.category" from "dummy_models" left join "dummy_has_one_models" on "dummy_has_one_models"."dummy_model_id" = "dummy_models"."id" order by dummy_models.id desc, dummy_has_one_models.name desc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+        $subject->forgetComputed();
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_has_one_models"."name" as "dummy_has_one.name", "dummy_has_one_models"."category" as "dummy_has_one.category" from "dummy_models" left join "dummy_has_one_models" on "dummy_has_one_models"."dummy_model_id" = "dummy_models"."id" order by dummy_models.id desc, dummy_has_one_models.name asc', $subject->getQuery()->toSql());
+
+        $subject->sort(2);
+        $subject->forgetComputed();
+        $this->assertEquals('select "dummy_models"."id" as "id", "dummy_has_one_models"."name" as "dummy_has_one.name", "dummy_has_one_models"."category" as "dummy_has_one.category" from "dummy_models" left join "dummy_has_one_models" on "dummy_has_one_models"."dummy_model_id" = "dummy_models"."id" order by dummy_models.id desc, dummy_has_one_models.name asc, dummy_has_one_models.category desc', $subject->getQuery()->toSql());
+    }
+
+    /** @test */
+    public function it_creates_a_multisort_query_builder_for_has_many_relation_columns()
+    {
+        factory(DummyModel::class)->create()->dummy_has_many()->saveMany(factory(DummyHasManyModel::class, 2)->make());
+
+        $subject = new LivewireDatatable(1);
+        $subject->multisort = true;
+        $subject->mount(DummyModel::class, ['id', 'dummy_has_many.name']);
+
+        $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_has_many_models.name), \'\', \'\') , \', \') from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+
+        $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_has_many_models.name), \'\', \'\') , \', \') from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc, `dummy_has_many.name` desc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+
+        $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_has_many_models.name), \'\', \'\') , \', \') from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc, `dummy_has_many.name` asc', $subject->getQuery()->toSql());
+
+        $subject->sort(0);
+
+        $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_has_many_models.name), \'\', \'\') , \', \') from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `dummy_has_many.name` asc, `id` asc', $subject->getQuery()->toSql());
+    }
+
+    /** @test */
+    public function it_creates_a_multisort_query_builder_for_has_many_relation_column_with_specific_aggregate()
+    {
+        factory(DummyModel::class)->create()->dummy_has_many()->saveMany(factory(DummyHasManyModel::class, 2)->make());
+
+        $subject = new LivewireDatatable(1);
+        $subject->multisort = true;
+        $subject->mount(DummyModel::class, ['id', 'dummy_has_many.id:avg']);
+
+        $this->assertEquals('select (select COALESCE(avg(dummy_has_many_models.id),0) from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.id:avg`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+
+        $this->assertEquals('select (select COALESCE(avg(dummy_has_many_models.id),0) from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.id:avg`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc, `dummy_has_many.id:avg` desc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+
+        $this->assertEquals('select (select COALESCE(avg(dummy_has_many_models.id),0) from "dummy_has_many_models" where "dummy_models"."id" = "dummy_has_many_models"."dummy_model_id") as `dummy_has_many.id:avg`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc, `dummy_has_many.id:avg` asc', $subject->getQuery()->toSql());
+    }
+
+    /** @test */
+    public function it_creates_a_multisort_query_builder_for_belongs_to_relation_columns()
+    {
+        factory(DummyModel::class)->create()->dummy_has_many()->saveMany(factory(DummyHasManyModel::class, 2)->make());
+
+        $subject = new LivewireDatatable(1);
+        $subject->multisort = true;
+        $subject->mount(DummyHasManyModel::class, ['id', 'dummy_model.name']);
+
+        $this->assertEquals('select "dummy_has_many_models"."id" as "id", "dummy_models"."name" as "dummy_model.name" from "dummy_has_many_models" left join "dummy_models" on "dummy_has_many_models"."dummy_model_id" = "dummy_models"."id" order by `id` desc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+        $subject->forgetComputed();
+
+        $this->assertEquals('select "dummy_has_many_models"."id" as "id", "dummy_models"."name" as "dummy_model.name" from "dummy_has_many_models" left join "dummy_models" on "dummy_has_many_models"."dummy_model_id" = "dummy_models"."id" order by dummy_has_many_models.id desc, dummy_models.name desc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+        $subject->forgetComputed();
+
+        $this->assertEquals('select "dummy_has_many_models"."id" as "id", "dummy_models"."name" as "dummy_model.name" from "dummy_has_many_models" left join "dummy_models" on "dummy_has_many_models"."dummy_model_id" = "dummy_models"."id" order by dummy_has_many_models.id desc, dummy_models.name asc', $subject->getQuery()->toSql());
+
+        $subject->sort(0);
+        $subject->forgetComputed();
+
+        $this->assertEquals('select "dummy_has_many_models"."id" as "id", "dummy_models"."name" as "dummy_model.name" from "dummy_has_many_models" left join "dummy_models" on "dummy_has_many_models"."dummy_model_id" = "dummy_models"."id" order by dummy_models.name asc, dummy_has_many_models.id asc', $subject->getQuery()->toSql());
+    }
+
+    /** @test */
+    public function it_creates_a_multisort_query_builder_for_belongs_to_many_relation_columns()
+    {
+        factory(DummyModel::class)->create()->dummy_belongs_to_many()->attach(factory(DummyBelongsToManyModel::class)->create());
+
+        $subject = new LivewireDatatable(1);
+        $subject->multisort = true;
+        $subject->mount(DummyModel::class, ['id', 'dummy_belongs_to_many.name']);
+
+        $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_belongs_to_many_models.name), \'\', \'\') , \', \') from "dummy_belongs_to_many_models" inner join "dummy_belongs_to_many_model_dummy_model" on "dummy_belongs_to_many_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_belongs_to_many_model_id" where "dummy_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_model_id" and "dummy_belongs_to_many_models"."deleted_at" is null) as `dummy_belongs_to_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+
+        $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_belongs_to_many_models.name), \'\', \'\') , \', \') from "dummy_belongs_to_many_models" inner join "dummy_belongs_to_many_model_dummy_model" on "dummy_belongs_to_many_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_belongs_to_many_model_id" where "dummy_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_model_id" and "dummy_belongs_to_many_models"."deleted_at" is null) as `dummy_belongs_to_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc, `dummy_belongs_to_many.name` desc', $subject->getQuery()->toSql());
+
+        $subject->sort(1);
+
+        $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_belongs_to_many_models.name), \'\', \'\') , \', \') from "dummy_belongs_to_many_models" inner join "dummy_belongs_to_many_model_dummy_model" on "dummy_belongs_to_many_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_belongs_to_many_model_id" where "dummy_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_model_id" and "dummy_belongs_to_many_models"."deleted_at" is null) as `dummy_belongs_to_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `id` desc, `dummy_belongs_to_many.name` asc', $subject->getQuery()->toSql());
+
+        $subject->sort(0);
+
+        $this->assertEquals('select (select group_concat(REPLACE(DISTINCT(dummy_belongs_to_many_models.name), \'\', \'\') , \', \') from "dummy_belongs_to_many_models" inner join "dummy_belongs_to_many_model_dummy_model" on "dummy_belongs_to_many_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_belongs_to_many_model_id" where "dummy_models"."id" = "dummy_belongs_to_many_model_dummy_model"."dummy_model_id" and "dummy_belongs_to_many_models"."deleted_at" is null) as `dummy_belongs_to_many.name`, "dummy_models"."id" as "id" from "dummy_models" order by `dummy_belongs_to_many.name` asc, `id` asc', $subject->getQuery()->toSql());
+    }
+}

--- a/tests/LivewireDatatableQueryBuilderTest.php
+++ b/tests/LivewireDatatableQueryBuilderTest.php
@@ -187,7 +187,7 @@ class LivewireDatatableQueryBuilderTest extends TestCase
     }
 
     /** @test */
-    public function it_creates_a__where_query_for_belongs_to_many_relation_columns()
+    public function it_creates_a_where_query_for_belongs_to_many_relation_columns()
     {
         factory(DummyModel::class)->create()->dummy_belongs_to_many()->attach(factory(DummyBelongsToManyModel::class)->create());
 

--- a/tests/PutSortToSessionTest.php
+++ b/tests/PutSortToSessionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Mediconesystems\LivewireDatatables\Tests;
+
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Mediconesystems\LivewireDatatables\Http\Livewire\LivewireDatatable;
+use Mediconesystems\LivewireDatatables\Tests\Models\DummyModel;
+
+class PutSortToSessionTest extends TestCase
+{
+    /** @test */
+    public function it_saves_sort_to_session_when_not_in_multisort()
+    {
+        factory(DummyModel::class)->create();
+
+        $subject = Livewire::test(LivewireDatatable::class, [
+            'model' => DummyModel::class,
+        ]);
+
+        $subject->call('sort', 1);
+        $this->assertSession(1, ['1|desc'], $sortSessionKey = Str::snake(Str::afterLast(LivewireDatatable::class, '\\')) . '_sort');
+
+        $subject->call('sort', 1);
+        $this->assertSession(1, ['1|asc'], $sortSessionKey);
+
+        $subject->call('sort', 0);
+        $this->assertSession(1, ['0|desc'], $sortSessionKey);
+    }
+
+    /** @test */
+    public function it_saves_sort_to_session_when_in_multisort()
+    {
+        factory(DummyModel::class)->create();
+
+        $subject = Livewire::test(LivewireDatatable::class, [
+            'model' => DummyModel::class,
+            'multisort' => true
+        ]);
+
+        $subject->call('sort', 1);
+        $this->assertSession(2, ['0|desc', '1|desc'], $multisortSessionKey = Str::snake(Str::afterLast(LivewireDatatable::class, '\\')) . '_multisort');
+
+        $subject->call('sort', 1);
+        $this->assertSession(2, ['0|desc', '1|asc'], $multisortSessionKey);
+
+        $subject->call('sort', 2);
+        $this->assertSession(3, ['0|desc', '1|asc', '2|desc'], $multisortSessionKey);
+    }
+
+    private function assertSession(int $expectedCount, array $columnsIndexDirection, string $sessionKey)
+    {
+        $session = session()->get($sessionKey);
+        $this->assertCount($expectedCount, $session);
+        foreach ($columnsIndexDirection as $columnIndexDirection) {
+            $this->assertTrue(in_array($columnIndexDirection, $session));
+        }
+
+    }
+}


### PR DESCRIPTION
Hi there! Thanks for this great package. I'd like to contribute a feature that lets the user sort by multiple columns (multisort). It resolves [this issue](https://github.com/MedicOneSystems/livewire-datatables/issues/313). Please take a look whenever you get a chance and let me know if you'd like me to make any changes. Thanks!

**Summary**
This PR introduces "multisort", a feature that allows sorting datatables by multiple columns. 

**Key changes in** `LivewireDatatable` class
- `$sort` property is now an array
- Multisort can be toggled through property `$multisort`. Multisort is disabled by default.
- `$direction` property in `LivewireDatatable` has been removed. Each column s now has its own direction, The possible values for direction are `asc, desc, null`. Example `$sort = ['column1|asc', 'column2|desc']`

- New tests: 
In LivewireDatatableTemplateTest:
`it_can_set_sort_from_property_using_column_index,
 it_can_set_multisort_from_property_using_array,                    it_can_set_sort_from_property_using_column_name_and_direction,                               it_can_set_sort_from_property_using_column_index_and_direction`
 
 LivewireDatatableMultisortQueryBuilderTest, PutSortToSessionTest