### PR TITLE
Add "Row Index" column type

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -4,6 +4,7 @@ namespace Mediconesystems\LivewireDatatables;
 
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Mediconesystems\LivewireDatatables\Http\Livewire\LivewireDatatable;
 
 class Column
 {
@@ -53,6 +54,18 @@ class Column
             $column->label = array_reverse(preg_split('/ as /i', $name))[1];
             $column->base = preg_split('/ as /i', $name)[0];
         }
+
+        return $column;
+    }
+
+    public static function index(LivewireDatatable $datatable, $attribute = 'id')
+    {
+        $column = new static;
+        $column->name = $attribute;
+        $column->label = '#';
+        $column->callback = function() use($datatable) {
+            return $datatable->page * $datatable->perPage - $datatable->perPage + $datatable->row++;
+        };
 
         return $column;
     }

--- a/src/Column.php
+++ b/src/Column.php
@@ -63,7 +63,7 @@ class Column
         $column = new static;
         $column->name = $attribute;
         $column->label = '#';
-        $column->callback = function() use($datatable) {
+        $column->callback = function () use($datatable) {
             return $datatable->page * $datatable->perPage - $datatable->perPage + $datatable->row++;
         };
 

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -66,6 +66,7 @@ class LivewireDatatable extends Component
     public $persistSort = true;
     public $persistPerPage = true;
     public $persistFilters = true;
+    public $row = 1;
 
     /**
      * @var array List your groups and the corresponding label (or translation) here.
@@ -941,6 +942,8 @@ class LivewireDatatable extends Component
 
     public function getResultsProperty()
     {
+        $this->row = 1;
+
         return $this->mapCallbacks(
             $this->getQuery()->paginate($this->perPage)
         );


### PR DESCRIPTION
This feature is unlikely to be used. But to be honest I'm really looking forward to how to add Laravel's `$loop->increment` into this package. I read the documentation, and I don't see any function related to the incremental feature.

I think it could be nice to have such a feature in this package because it helps me a lot.

The usage is simply by using:
```php
\Mediconesystems\LivewireDatatables\Column::index($this);
```