### PR TITLE
Get $model from builder() method

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -184,7 +184,7 @@ class LivewireDatatable extends Component
     }
 
     public function mount(
-        $model = null,
+        $model = false,
         $include = [],
         $exclude = [],
         $hide = [],
@@ -231,7 +231,7 @@ class LivewireDatatable extends Component
         $this->initialiseFilters();
         $this->initialisePerPage();
         $this->initialiseColumnGroups();
-        $this->model = is_null($this->model) ? get_class($this->builder()->getModel()) : $this->model;
+        $this->model = $this->model ?: get_class($this->builder()->getModel());
     }
 
     // save settings

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -231,7 +231,7 @@ class LivewireDatatable extends Component
         $this->initialiseFilters();
         $this->initialisePerPage();
         $this->initialiseColumnGroups();
-	$this->model = is_null($this->model) ? get_class($this->builder()->getModel()) : $this->model;
+        $this->model = is_null($this->model) ? get_class($this->builder()->getModel()) : $this->model;
     }
 
     // save settings

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -231,6 +231,7 @@ class LivewireDatatable extends Component
         $this->initialiseFilters();
         $this->initialisePerPage();
         $this->initialiseColumnGroups();
+	$this->model = is_null($this->model) ? get_class($this->builder()->getModel()) : $this->model;
     }
 
     // save settings


### PR DESCRIPTION
Gets the ```$model``` from the ```builder()``` method if a ```$model``` is not supplied.