### PR TITLE
Takes into account hidden columns when displaying summary row

### DIFF
--- a/resources/views/livewire/datatables/datatable.blade.php
+++ b/resources/views/livewire/datatables/datatable.blade.php
@@ -186,13 +186,15 @@
                     @if ($this->hasSummaryRow())
                         <div class="table-row p-1">
                             @foreach($this->columns as $column)
-                                @if ($column['summary'])
-                                    <div class="table-cell px-6 py-2 whitespace-no-wrap @if($column['align'] === 'right') text-right @elseif($column['align'] === 'center') text-center @else text-left @endif {{ $this->cellClasses($row, $column) }}">
-                                        {{ $this->summarize($column['name']) }}
-                                    </div>
-                                @else
-                                    <div class="table-cell"></div>
-                                @endif
+                                @unless($column['hidden'])
+                                    @if ($column['summary'])
+                                        <div class="table-cell px-6 py-2 whitespace-no-wrap @if($column['align'] === 'right') text-right @elseif($column['align'] === 'center') text-center @else text-left @endif {{ $this->cellClasses($row, $column) }}">
+                                            {{ $this->summarize($column['name']) }}
+                                        </div>
+                                    @else
+                                        <div class="table-cell"></div>
+                                    @endif
+                                @endunless
                             @endforeach
                         </div>
                     @endif


### PR DESCRIPTION
Hi !

First of all, great work on this lib, it's really a lifesaver for me.

Today, I tested the summary row feature introduced recently, and I saw a bug : when a column left of a summary is hidden, it's still taken into account when creating the table cells of the summary row.

So I'm offering a quick fix here. Everything seems to work on my end, I'll let you test and get back to me if I need to do any changes.

I got some other PRs coming in the future from the customizations I did on my end that could benefit others