### PR TITLE
Change to allow use of checkbox without 'CanPinRecords'

### DIFF
--- a/resources/views/livewire/datatables/checkbox.blade.php
+++ b/resources/views/livewire/datatables/checkbox.blade.php
@@ -3,7 +3,7 @@
         type="checkbox"
         wire:model="selected"
         value="{{ $value }}"
-        @if (in_array($value, $this->pinnedRecords)) checked @endif
+        @if (property_exists($this, 'pinnedRecords') && in_array($value, $this->pinnedRecords)) checked @endif
         class="w-4 h-4 mt-1 text-blue-600 form-checkbox transition duration-150 ease-in-out"
     />
 </div>


### PR DESCRIPTION
This change allows you to use the checkbox column even if you're not using the `CanPinRecords` trait.  

Without this in place, rendering the datatable throws a `Property [$pinnedRecords] not found on component`.

With it, you can use the checkbox for pinned records as normal, or add a button, etc. to one of the slots to do something with the selected records.

Thanks!