### PR TITLE
Fix issue: Column::callback(): Argument #1 ($columns) must be of type…

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -107,15 +107,15 @@ class Column
     /**
      * Make a callback function.
      *
-     * @param $columns      string  The (comma separated) columns that should be retrieved from the database.
-     *                              Is being translated directly into the `.sql`.
-     * @param $callback     Closure A callback that defines how the retrieved columns are processed.
-     * @param $params       Array   Optional additional parameters that are passed to the given Closure.
-     * @param $callbackName string  Optional string that defines the 'name' of the column.
-     *                              Leave empty to let livewire autogenerate a distinct value.
+     * @param $columns      Array|string    The (comma separated) columns that should be retrieved from the database.
+     *                                      Is being translated directly into the `.sql`.
+     * @param $callback     Closure         A callback that defines how the retrieved columns are processed.
+     * @param $params       Array           Optional additional parameters that are passed to the given Closure.
+     * @param $callbackName string          Optional string that defines the 'name' of the column.
+     *                                      Leave empty to let livewire autogenerate a distinct value.
      */
     public static function callback(
-        string $columns,
+        array|string $columns,
         Closure $callback,
         array $params = [],
         ?string $callbackName = null


### PR DESCRIPTION
## Error message:
Column::callback(): Argument #1 ($columns) must be of type string, array given

## Issue:
In `src/Column.php:118` you set the type to "string" when it should be Array|String