### PR TITLE
Column::callback(): Argument #2 ($callback) must be of type Closure, string given

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -109,14 +109,14 @@ class Column
      *
      * @param $columns      Array|string    The (comma separated) columns that should be retrieved from the database.
      *                                      Is being translated directly into the `.sql`.
-     * @param $callback     Closure         A callback that defines how the retrieved columns are processed.
+     * @param $callback     Closure|string  A callback that defines how the retrieved columns are processed.
      * @param $params       Array           Optional additional parameters that are passed to the given Closure.
      * @param $callbackName string          Optional string that defines the 'name' of the column.
      *                                      Leave empty to let livewire autogenerate a distinct value.
      */
     public static function callback(
         array|string $columns,
-        Closure $callback,
+        Closure|string $callback,
         array $params = [],
         ?string $callbackName = null
     ) {


### PR DESCRIPTION
## Error message:
Mediconesystems\LivewireDatatables\Column::callback(): Argument #2 ($callback) must be of type Closure, string given

## Issue:
In src/Column.php:119 you set the type to "Closure" when it should be Closure|string

## Steps to reproduce:
Add something like this in your columns() method:
```php
 Column::callback(['id', 'title'], 'someLocalMethod');
```