### PR TITLE
The backtick on the sort string for sqlserv breaks query.

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -726,7 +726,7 @@ class LivewireDatatable extends Component
              default:
                 return $dbTable == 'pgsql' || $dbTable == 'sqlsrv'
                     ? new Expression('"' . $column['name'] . '"')
-                    : new Expression('`' . $column['name'] . '`');
+                    : new Expression("'" . $column['name'] . "'");
                 break;
         }
     }


### PR DESCRIPTION
This doesn't seem to be required for postgres either.  This is related to issue #434 