### PR TITLE
Add support to set default date filter start and end to support other Date/DateTime types.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "shaneburrell/livewire-datatables",
+    "name": "mediconesystems/livewire-datatables",
     "description": "",
     "keywords": [
         "mediconesystems",
@@ -12,11 +12,6 @@
         {
             "name": "Mark Salmon",
             "email": "mark.salmon@mediconesystems.com",
-            "role": "Developer"
-        },
-        {
-            "name": "Shane Burrell",
-            "email": "shane@shaneburrell.com",
             "role": "Developer"
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mediconesystems/livewire-datatables",
+    "name": "shaneburrell/livewire-datatables",
     "description": "",
     "keywords": [
         "mediconesystems",
@@ -12,6 +12,11 @@
         {
             "name": "Mark Salmon",
             "email": "mark.salmon@mediconesystems.com",
+            "role": "Developer"
+        },
+        {
+            "name": "Shane Burrell",
+            "email": "shane@shaneburrell.com",
             "role": "Developer"
         }
     ],

--- a/config/livewire-datatables.php
+++ b/config/livewire-datatables.php
@@ -14,7 +14,6 @@ return [
     'default_time_format' => 'H:i',
     'default_date_format' => 'd/m/Y',
 
-
     /*
     |--------------------------------------------------------------------------
     | Default Carbon Formats
@@ -31,7 +30,6 @@ return [
     // Defaults that work with smalldatetime in SQL Server
     //  'default_time_start' => '1900-01-01',
     //  'default_time_end' => '2079-06-06',
-
 
     /*
     |--------------------------------------------------------------------------

--- a/config/livewire-datatables.php
+++ b/config/livewire-datatables.php
@@ -14,6 +14,25 @@ return [
     'default_time_format' => 'H:i',
     'default_date_format' => 'd/m/Y',
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Carbon Formats
+    |--------------------------------------------------------------------------
+    | The default formats that are used for TimeColumn & DateColumn.
+    | You can use the formatting characters from the PHP DateTime class.
+    | More info: https://www.php.net/manual/en/datetime.format.php
+    |
+    */
+
+    'default_time_start' => '0000-00-00',
+    'default_time_end' => '9999-12-31',
+
+    // Defaults that work with smalldatetime in SQL Server
+    //  'default_time_start' => '1900-01-01',
+    //  'default_time_end' => '2079-06-06',
+
+
     /*
     |--------------------------------------------------------------------------
     | Surpress Search Highlights

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1476,7 +1476,7 @@ class LivewireDatatable extends Component
                 }
                 $query->whereBetween($this->getColumnFilterStatement($index)[0], [
                     isset($filter['start']) && $filter['start'] != '' ? $filter['start'] : config('livewire-datatables.default_time_start', '0000-00-00'),
-                    isset($filter['end']) && $filter['end'] != '' ? $filter['end'] : config('livewire-datatables.default_time_end', '9999-12-31')
+                    isset($filter['end']) && $filter['end'] != '' ? $filter['end'] : config('livewire-datatables.default_time_end', '9999-12-31'),
                 ]);
             }
         });

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1475,8 +1475,8 @@ class LivewireDatatable extends Component
                     break;
                 }
                 $query->whereBetween($this->getColumnFilterStatement($index)[0], [
-                    isset($filter['start']) && $filter['start'] != '' ? $filter['start'] : '0000-00-00',
-                    isset($filter['end']) && $filter['end'] != '' ? $filter['end'] : '9999-12-31',
+                    isset($filter['start']) && $filter['start'] != '' ? $filter['start'] : config('livewire-datatables.default_time_start', '0000-00-00'),
+                    isset($filter['end']) && $filter['end'] != '' ? $filter['end'] : config('livewire-datatables.default_time_end', '9999-12-31')
                 ]);
             }
         });


### PR DESCRIPTION
The default hard set in code does not work with smalldatetime in MS SQL. This makes it configurable.