### PR TITLE
php 8 is required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
+        "php": "^8.0",
         "illuminate/support": "^7.0|^8.0|^9.0",
         "livewire/livewire": "^2.4.4",
         "maatwebsite/excel": "^3.1",


### PR DESCRIPTION
Since [this commit](https://github.com/MedicOneSystems/livewire-datatables/commit/258ed099beea44fec6b5bd84c6a054a36a914402) PHP8 is required. I think latest package release supporting PHP 7 is [0.9.1](https://github.com/MedicOneSystems/livewire-datatables/releases/tag/v0.9.1)