### PR TITLE
add single quotes around id in call to delete function

### DIFF
--- a/resources/views/livewire/datatables/delete.blade.php
+++ b/resources/views/livewire/datatables/delete.blade.php
@@ -44,7 +44,7 @@
                                 </button>
                             </span>
                             <span x-on:click="working = !working">
-                                <button wire:click="delete({{ $value }})" class="w-32 shadow-sm inline-flex justify-center items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:border-red-700 focus:shadow-outline-teal active:bg-red-700 transition ease-in-out duration-150">
+                                <button wire:click="delete('{{ $value }}')" class="w-32 shadow-sm inline-flex justify-center items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:border-red-700 focus:shadow-outline-teal active:bg-red-700 transition ease-in-out duration-150">
                                     {{ __('Yes')}}
                                 </button>
                             </span>


### PR DESCRIPTION
fix delete template to allow the call to delete function on component to work with uuids containing minus signs