### PR TITLE
Bugfix for relations in resolveColumnName method

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -436,15 +436,15 @@ class LivewireDatatable extends Component
         while (count($relations) > 0) {
             $relation = array_shift($relations);
 
-            $useThrough = collect($this->query->getQuery()->joins)
-                ->pluck('table')
-                ->contains($relatedQuery->getRelation($relation)->getRelated()->getTable());
-
             if ($relatedQuery->getRelation($relation) instanceof HasMany || $relatedQuery->getRelation($relation) instanceof HasManyThrough || $relatedQuery->getRelation($relation) instanceof BelongsToMany) {
                 $this->query->customWithAggregate($aggregateName, $column->aggregate ?? 'count', $columnName, $column->name);
 
                 return null;
             }
+
+            $useThrough = collect($this->query->getQuery()->joins)
+                ->pluck('table')
+                ->contains($relatedQuery->getRelation($relation)->getRelated()->getTable());
 
             $relatedQuery = $this->query->joinRelation($relation, null, 'left', $useThrough, $relatedQuery);
         }


### PR DESCRIPTION
Set variable `$useThrough` **AFTER** checking if relation is an instance of HasMany, HasManyThrough or BelongsToMany. Otherwise, it will return an error because no joins property exists for `$this->query->getQuery()`