### PR TITLE
re-run resolve function for columns containing dot in the name

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -370,7 +370,7 @@ class LivewireDatatable extends Component
             ->reject(function ($column) use ($export) {
                 return $column->scope || $column->type === 'label' || ($export && $column->preventExport);
             })->map(function ($column) {
-                if ($column->select) {
+                if ($column->select && !Str::contains($column->name, '.')) {
                     return $column;
                 }
 


### PR DESCRIPTION
This one should solve #505

The issue when exporting was both export and re-render are happening in the single request. The 2nd time query is built, it starts fresh (from builder method) but columns are already resolved. 

Column doesn't have any join info stored in it so the join is missing and thus generating Unknown column error. It is because resolveColumnName will change query directly.

That being said, there is a workaround for this bug. If we define builder function in our class, and we do a manual join there, then everything will be fine. But still, I think this one should be solved in the library. 

