### PR TITLE
Bugfix checkboxes behavior when search or filters are active

### DIFF
--- a/resources/views/livewire/datatables/datatable.blade.php
+++ b/resources/views/livewire/datatables/datatable.blade.php
@@ -109,7 +109,7 @@
                                     @unless($column['hidden'])
                                         <div class="flex justify-center table-cell w-32 h-12 px-6 py-4 overflow-hidden text-xs font-medium tracking-wider text-left text-gray-500 uppercase align-top border-b border-gray-200 bg-gray-50 leading-4 focus:outline-none">
                                             <div class="px-3 py-1 rounded @if(count($selected)) bg-orange-400 @else bg-gray-200 @endif text-white text-center">
-                                                {{ count($selected) }}
+                                                {{ count($visibleSelected) }}
                                             </div>
                                         </div>
                                     @endunless

--- a/resources/views/livewire/datatables/filters/checkbox.blade.php
+++ b/resources/views/livewire/datatables/filters/checkbox.blade.php
@@ -7,7 +7,7 @@
         type="checkbox"
         wire:click="toggleSelectAll"
         class="w-4 h-4 mt-1 text-blue-600 form-checkbox transition duration-150 ease-in-out"
-        @if(count($selected) === $this->results->total()) checked @endif
+        @if($this->results->total() === count($visibleSelected)) checked @endif
         />
     </div>
 </div>

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1635,16 +1635,16 @@ class LivewireDatatable extends Component
 
     public function toggleSelectAll()
     {
-        $visible_chekboxes = $this->getQuery()->get()->pluck('checkbox_attribute')->toArray();
-        $visible_chekboxes = array_map('strval', $visible_chekboxes);
+        $visible_checkboxes = $this->getQuery()->get()->pluck('checkbox_attribute')->toArray();
+        $visible_checkboxes = array_map('strval', $visible_checkboxes);
         if ($this->searchOrFilterActive()) {
-            if (count($this->visibleSelected) === count($visible_chekboxes)) {
-                $this->selected = array_values(array_diff($this->selected, $visible_chekboxes));
+            if (count($this->visibleSelected) === count($visible_checkboxes)) {
+                $this->selected = array_values(array_diff($this->selected, $visible_checkboxes));
                 $this->visibleSelected = [];
             } else {
-                $this->selected = array_unique(array_merge($this->selected, $visible_chekboxes));
+                $this->selected = array_unique(array_merge($this->selected, $visible_checkboxes));
                 sort($this->selected);
-                $this->visibleSelected = $visible_chekboxes;
+                $this->visibleSelected = $visible_checkboxes;
             }
         } else {
             if (count($this->selected) === $this->getQuery()->getCountForPagination()) {

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -64,6 +64,7 @@ class LivewireDatatable extends Component
     public $persistSort = true;
     public $persistPerPage = true;
     public $persistFilters = true;
+    public $visibleSelected = [];
     public $row = 1;
 
     public $tablePrefix = '';
@@ -216,6 +217,7 @@ class LivewireDatatable extends Component
 
     public function updatedSearch()
     {
+        $this->visibleSelected = ($this->search) ? array_intersect($this->getQuery()->get()->pluck('checkbox_attribute')->toArray(), $this->selected) : $this->selected;
         $this->setPage(1);
     }
 
@@ -640,21 +642,21 @@ class LivewireDatatable extends Component
                 return Str::before($column['select'], ' AS ');
                 break;
 
-             default:
+            default:
 
-                 switch ($dbtable) {
-                     case 'mysql':
-                         return new Expression('`' . $column['name'] . '`');
-                         break;
-                     case 'pgsql':
-                         return new Expression('"' . $column['name'] . '"');
-                         break;
-                     case 'sqlsrv':
-                         return new Expression("'" . $column['name'] . "'");
-                         break;
-                     default:
-                         return new Expression("'" . $column['name'] . "'");
-                 }
+                switch ($dbtable) {
+                    case 'mysql':
+                        return new Expression('`' . $column['name'] . '`');
+                        break;
+                    case 'pgsql':
+                        return new Expression('"' . $column['name'] . '"');
+                        break;
+                    case 'sqlsrv':
+                        return new Expression("'" . $column['name'] . "'");
+                        break;
+                    default:
+                        return new Expression("'" . $column['name'] . "'");
+                }
         }
     }
 
@@ -806,6 +808,7 @@ class LivewireDatatable extends Component
     public function doBooleanFilter($index, $value)
     {
         $this->activeBooleanFilters[$index] = $value;
+        $this->setVisibleSelected();
         $this->setPage(1);
         $this->setSessionStoredFilters();
     }
@@ -813,6 +816,7 @@ class LivewireDatatable extends Component
     public function doSelectFilter($index, $value)
     {
         $this->activeSelectFilters[$index][] = $value;
+        $this->setVisibleSelected();
         $this->setPage(1);
         $this->setSessionStoredFilters();
     }
@@ -822,7 +826,7 @@ class LivewireDatatable extends Component
         foreach (explode(' ', $value) as $val) {
             $this->activeTextFilters[$index][] = $val;
         }
-
+        $this->setVisibleSelected();
         $this->setPage(1);
         $this->setSessionStoredFilters();
     }
@@ -830,6 +834,7 @@ class LivewireDatatable extends Component
     public function doDateFilterStart($index, $start)
     {
         $this->activeDateFilters[$index]['start'] = $start;
+        $this->setVisibleSelected();
         $this->setPage(1);
         $this->setSessionStoredFilters();
     }
@@ -837,6 +842,7 @@ class LivewireDatatable extends Component
     public function doDateFilterEnd($index, $end)
     {
         $this->activeDateFilters[$index]['end'] = $end;
+        $this->setVisibleSelected();
         $this->setPage(1);
         $this->setSessionStoredFilters();
     }
@@ -844,6 +850,7 @@ class LivewireDatatable extends Component
     public function doTimeFilterStart($index, $start)
     {
         $this->activeTimeFilters[$index]['start'] = $start;
+        $this->setVisibleSelected();
         $this->setPage(1);
         $this->setSessionStoredFilters();
     }
@@ -851,6 +858,7 @@ class LivewireDatatable extends Component
     public function doTimeFilterEnd($index, $end)
     {
         $this->activeTimeFilters[$index]['end'] = $end;
+        $this->setVisibleSelected();
         $this->setPage(1);
         $this->setSessionStoredFilters();
     }
@@ -859,6 +867,7 @@ class LivewireDatatable extends Component
     {
         $this->activeNumberFilters[$index]['start'] = ($start != '') ? (int) $start : null;
         $this->clearEmptyNumberFilter($index);
+        $this->setVisibleSelected();
         $this->setPage(1);
         $this->setSessionStoredFilters();
     }
@@ -867,6 +876,7 @@ class LivewireDatatable extends Component
     {
         $this->activeNumberFilters[$index]['end'] = ($end != '') ? (int) $end : null;
         $this->clearEmptyNumberFilter($index);
+        $this->setVisibleSelected();
         $this->setPage(1);
         $this->setSessionStoredFilters();
     }
@@ -883,6 +893,7 @@ class LivewireDatatable extends Component
     public function removeSelectFilter($column, $key = null)
     {
         unset($this->activeSelectFilters[$column][$key]);
+        $this->visibleSelected = $this->selected;
         if (count($this->activeSelectFilters[$column]) < 1) {
             unset($this->activeSelectFilters[$column]);
         }
@@ -900,6 +911,7 @@ class LivewireDatatable extends Component
         $this->activeNumberFilters = [];
         $this->complexQuery = null;
         $this->userFilter = null;
+        $this->visibleSelected = $this->selected;
         $this->setPage(1);
         $this->setSessionStoredFilters();
 
@@ -909,6 +921,7 @@ class LivewireDatatable extends Component
     public function removeBooleanFilter($column)
     {
         unset($this->activeBooleanFilters[$column]);
+        $this->visibleSelected = $this->selected;
         $this->setSessionStoredFilters();
     }
 
@@ -922,12 +935,14 @@ class LivewireDatatable extends Component
         } else {
             unset($this->activeTextFilters[$column]);
         }
+        $this->visibleSelected = $this->selected;
         $this->setSessionStoredFilters();
     }
 
     public function removeNumberFilter($column)
     {
         unset($this->activeNumberFilters[$column]);
+        $this->visibleSelected = $this->selected;
         $this->setSessionStoredFilters();
     }
 
@@ -1620,12 +1635,36 @@ class LivewireDatatable extends Component
 
     public function toggleSelectAll()
     {
-        if (count($this->selected) === $this->getQuery()->getCountForPagination()) {
-            $this->selected = [];
+        $visible_chekboxes = $this->getQuery()->get()->pluck('checkbox_attribute')->toArray();
+        $visible_chekboxes = array_map('strval', $visible_chekboxes);
+        if ($this->searchOrFilterActive()) {
+            if (count($this->visibleSelected) === count($visible_chekboxes)) {
+                $this->selected = array_values(array_diff($this->selected, $visible_chekboxes));
+                $this->visibleSelected = [];
+            } else {
+                $this->selected = array_unique(array_merge($this->selected, $visible_chekboxes));
+                sort($this->selected);
+                $this->visibleSelected = $visible_chekboxes;
+            }
         } else {
-            $this->selected = $this->checkboxQuery()->values()->toArray();
+            if (count($this->selected) === $this->getQuery()->getCountForPagination()) {
+                $this->selected = [];
+            } else {
+                $this->selected = $this->checkboxQuery()->values()->toArray();
+            }
+            $this->visibleSelected = $this->selected;
         }
+        
         $this->forgetComputed();
+    }
+
+    public function updatedSelected()
+    {
+        if ($this->searchOrFilterActive()) {
+            $this->setVisibleSelected();
+        } else {
+            $this->visibleSelected = $this->selected;
+        }
     }
 
     public function rowIsSelected($row)
@@ -1737,5 +1776,16 @@ class LivewireDatatable extends Component
         }
 
         $this->massActionOption = null;
+    }
+
+    private function searchOrFilterActive()
+    {
+        return (!empty($this->search) || $this->getActiveFiltersProperty());
+    }
+
+    private function setVisibleSelected()
+    {
+        $this->visibleSelected = array_intersect($this->getQuery()->get()->pluck('checkbox_attribute')->toArray(), $this->selected);
+        $this->visibleSelected = array_map('strval', $this->visibleSelected);
     }
 }

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -1654,7 +1654,7 @@ class LivewireDatatable extends Component
             }
             $this->visibleSelected = $this->selected;
         }
-        
+
         $this->forgetComputed();
     }
 
@@ -1780,7 +1780,7 @@ class LivewireDatatable extends Component
 
     private function searchOrFilterActive()
     {
-        return (!empty($this->search) || $this->getActiveFiltersProperty());
+        return ! empty($this->search) || $this->getActiveFiltersProperty();
     }
 
     private function setVisibleSelected()


### PR DESCRIPTION
If the search or filter is active, we must display the count of checked rows only for "visible" items (results of search or filtered results). Therefore, the toggleSelectAll() method must also check or uncheck all "visible" items when the search or filters are active.
See the gif below in order to view the correct behavior (what this PR brings)
![bugfix-checkboxes-beahavior-livewire-datatables](https://user-images.githubusercontent.com/16756085/200591652-37d2c465-6d4d-4ca4-b54b-869ed085374a.gif)
