### PR TITLE
Added defaultFilters to Livewire Datatables

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,34 @@ class CallbackDemoTable extends LivewireDatatable
 }
 ```
 
+### Default Filters
+
+If you want to have a default filter applied to your table, you can use the `defaultFilters` property. The `defaultFilter` should be an Array of column names and the default filter value to use for. When a persisted filter (`$this->persistFilters` is true and session values are available) is available, it will override the default filters.
+
+In the example below, the table will by default be filtered by rows where the _deleted_at_ column is false. If the user has a persisted filter for the _deleted_at_ column, the default filter will be ignored.
+
+```php
+class CallbackDemoTable extends LivewireDatatable
+{
+    public $defaultFilters = [
+        'deleted_at' => '0',
+    ];
+
+    public function builder()
+    {
+        return User::query()->withTrashed();
+    }
+
+    public function columns()
+    {
+        return [
+            Column::name('id'),
+            BooleanColumn::name('deleted_at')->filterable(),
+        ];
+    }
+}
+```
+
 ### Views
 You can specify that a column's output is piped directly into a separate blade view template.
 - Template is specified using ususal laravel view helper syntax

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -36,6 +36,7 @@ class LivewireDatatable extends Component
     public $activeBooleanFilters = [];
     public $activeTextFilters = [];
     public $activeNumberFilters = [];
+    public $defaultFilters = [];
     public $hideHeader;
     public $hidePagination;
     public $perPage;
@@ -265,6 +266,7 @@ class LivewireDatatable extends Component
         $this->initialiseSearch();
         $this->initialiseSort();
         $this->initialiseHiddenColumns();
+        $this->initialiseDefaultFilters();
         $this->initialiseFilters();
         $this->initialisePerPage();
         $this->initialiseColumnGroups();
@@ -587,6 +589,52 @@ class LivewireDatatable extends Component
         }, $this->columns);
     }
 
+    public function initialiseDefaultFilters()
+    {
+        if(! $this->defaultFilters || ! is_array($this->defaultFilters) || count($this->defaultFilters) === 0) {
+            return;
+        }
+
+        $columns = collect($this->columns);
+
+
+        foreach ($this->defaultFilters as $columnName => $value) {
+            $columnIndex = $columns->search(function ($column) use ($columnName) {
+                return $column['name'] === $columnName;
+            });
+
+            if ($columnIndex === false) {
+                continue;
+            }
+
+            $column = $columns[$columnIndex];
+
+            if ($column['type'] === 'string') {
+                $this->activeTextFilters[$columnIndex] = $value;
+            }
+
+            if ($column['type'] === 'boolean') {
+                $this->activeBooleanFilters[$columnIndex] = $value;
+            }
+
+            if ($column['type'] === 'select') {
+                $this->activeSelectFilters[$columnIndex] = $value;
+            }
+
+            if ($column['type'] === 'date') {
+                $this->activeDateFilters[$columnIndex] = $value;
+            }
+
+            if ($column['type'] === 'time') {
+                $this->activeTimeFilters[$columnIndex] = $value;
+            }
+
+            if ($column['type'] === 'number') {
+                $this->activeNumberFilters[$columnIndex] = $value;
+            }
+        }
+    }
+
     public function initialiseFilters()
     {
         if (! $this->persistFilters) {
@@ -595,12 +643,29 @@ class LivewireDatatable extends Component
 
         $filters = session()->get($this->sessionStorageKey() . '_filter');
 
-        $this->activeBooleanFilters = $filters['boolean'] ?? [];
-        $this->activeSelectFilters = $filters['select'] ?? [];
-        $this->activeTextFilters = $filters['text'] ?? [];
-        $this->activeDateFilters = $filters['date'] ?? [];
-        $this->activeTimeFilters = $filters['time'] ?? [];
-        $this->activeNumberFilters = $filters['number'] ?? [];
+        if(!empty($filters['text'])) {
+            $this->activeTextFilters = $filters['text'];
+        }
+
+        if(!empty($filters['boolean'])) {
+            $this->activeBooleanFilters = $filters['boolean'];
+        }
+
+        if(!empty($filters['select'])) {
+            $this->activeSelectFilters = $filters['select'];
+        }
+
+        if(!empty($filters['date'])) {
+            $this->activeDateFilters = $filters['date'];
+        }
+
+        if(!empty($filters['time'])) {
+            $this->activeTimeFilters = $filters['time'];
+        }
+
+        if(!empty($filters['number'])) {
+            $this->activeNumberFilters = $filters['number'];
+        }
 
         if (isset($filters['search'])) {
             $this->search = $filters['search'];


### PR DESCRIPTION
Added defaultFilters. The defaultFilters should be an _Array_ of column names and the default filter value to use for. 
When a persisted filter ($this->persistFilters is true and session values are available) is available, it will override the default filters. 


<details>
<summary><b>Example Usage:</b></summary>

```php
 
<?php

use App\Models\User;
use Illuminate\Support\Carbon;
use Mediconesystems\LivewireDatatables\BooleanColumn;
use Mediconesystems\LivewireDatatables\Column;
use Mediconesystems\LivewireDatatables\Http\Livewire\LivewireDatatable;
use Mediconesystems\LivewireDatatables\NumberColumn;

class UsersTable extends LivewireDatatable
{
    public $defaultFilters = [
        'deleted_at' => '0',
    ];

    public function builder()
    {
        return User::query()->withTrashed();
    }

    public function columns()
    {
        $columns = [
            NumberColumn::name('ID'),
            BooleanColumn::name('deleted_at')->filterable()->label(__('Deleted')),
        ];

        return $columns;
    }
}


```

**In Action:**

https://user-images.githubusercontent.com/42392570/204001609-30f80de7-ea8e-476e-ad47-c5b630eaa07d.mp4

</details>



Refs & Closes #78 


