### PR TITLE
Bugfix : use LengthAwarePaginator in order to respect limit from Builder

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -19,6 +19,7 @@ use Mediconesystems\LivewireDatatables\Exports\DatatableExport;
 use Mediconesystems\LivewireDatatables\Traits\WithCallbacks;
 use Mediconesystems\LivewireDatatables\Traits\WithPresetDateFilters;
 use Mediconesystems\LivewireDatatables\Traits\WithPresetTimeFilters;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class LivewireDatatable extends Component
 {
@@ -1126,8 +1127,15 @@ class LivewireDatatable extends Component
     {
         $this->row = 1;
 
+        $paginatedQuery = $this->getQuery()->paginate($this->perPage);
+        $total = ($this->getQuery()->limit) ?: $paginatedQuery->total();
+        $paginatedQuery = new LengthAwarePaginator(
+            $paginatedQuery->toArray()['data'],
+            $paginatedQuery->total() < $total ? $paginatedQuery->total() : $total,
+            $this->perPage
+        );
         return $this->mapCallbacks(
-            $this->getQuery()->paginate($this->perPage)
+            $paginatedQuery
         );
     }
 


### PR DESCRIPTION
If the Query Builder uses a limit(), we need to use the [LengthAwarePaginator](https://laravel.com/api/8.x/Illuminate/Pagination/LengthAwarePaginator.html) to ensure that the limit is respected in the pagination.