### PR TITLE
Fixed a bug with the storage key saving for hidden columns

### DIFF
--- a/resources/views/livewire/datatables/filters/datetime.blade.php
+++ b/resources/views/livewire/datatables/filters/datetime.blade.php
@@ -6,7 +6,7 @@
             />
         <div class="absolute inset-y-0 right-0 pr-2 flex items-center">
             <button x-on:click="$refs.start.value=''" wire:click="doDatetimeFilterStart('{{ $index }}', '')" class="-mb-0.5 pr-1 flex text-gray-400 hover:text-red-600 focus:outline-none" tabindex="-1">
-                <x-datatables.icons.x-circle class="h-5 w-5 stroke-current" />
+                <x-icons.icons.x-circle class="h-5 w-5 stroke-current" />
             </button>
         </div>
     </div>
@@ -17,7 +17,7 @@
             />
         <div class="absolute inset-y-0 right-0 pr-2 flex items-center">
             <button x-on:click="$refs.end.value=''" wire:click="doDatetimeFilterEnd('{{ $index }}', '')" class="-mb-0.5 pr-1 flex text-gray-400 hover:text-red-600 focus:outline-none" tabindex="-1">
-                <x-datatables.icons.x-circle class="h-5 w-5 stroke-current" />
+                <x-icons.icons.x-circle class="h-5 w-5 stroke-current" />
             </button>
         </div>
     </div>

--- a/resources/views/livewire/datatables/filters/datetime.blade.php
+++ b/resources/views/livewire/datatables/filters/datetime.blade.php
@@ -6,7 +6,7 @@
             />
         <div class="absolute inset-y-0 right-0 pr-2 flex items-center">
             <button x-on:click="$refs.start.value=''" wire:click="doDatetimeFilterStart('{{ $index }}', '')" class="-mb-0.5 pr-1 flex text-gray-400 hover:text-red-600 focus:outline-none" tabindex="-1">
-                <x-icons.icons.x-circle class="h-5 w-5 stroke-current" />
+                <x-icons.x-circle class="h-5 w-5 stroke-current" />
             </button>
         </div>
     </div>
@@ -17,7 +17,7 @@
             />
         <div class="absolute inset-y-0 right-0 pr-2 flex items-center">
             <button x-on:click="$refs.end.value=''" wire:click="doDatetimeFilterEnd('{{ $index }}', '')" class="-mb-0.5 pr-1 flex text-gray-400 hover:text-red-600 focus:outline-none" tabindex="-1">
-                <x-icons.icons.x-circle class="h-5 w-5 stroke-current" />
+                <x-icons.x-circle class="h-5 w-5 stroke-current" />
             </button>
         </div>
     </div>

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -414,10 +414,9 @@ class LivewireDatatable extends Component
                     if ($column->select instanceof Expression) {
                         $sep_string = config('database.default') === 'pgsql' ? '"' : '`';
 
-                        if(version_compare("10.0.0", app()->version()) == -1) {
+                        if (version_compare("10.0.0", app()->version()) == -1) {
                             return new Expression($column->select->getQuery(DB::getQueryGrammar()) . ' AS ' . $sep_string . $column->name . $sep_string);
-                        }
-                        else {
+                        } else {
                             return new Expression($column->select->getQuery() . ' AS ' . $sep_string . $column->name . $sep_string);
                         }
                     }

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -415,7 +415,7 @@ class LivewireDatatable extends Component
                         $sep_string = config('database.default') === 'pgsql' ? '"' : '`';
 
                         if (version_compare("10.0.0", app()->version()) == -1) {
-                            return new Expression($column->select->getQuery(DB::getQueryGrammar()) . ' AS ' . $sep_string . $column->name . $sep_string);
+                            return new Expression($column->select->getValue(DB::getQueryGrammar()) . ' AS ' . $sep_string . $column->name . $sep_string);
                         } else {
                             return new Expression($column->select->getQuery() . ' AS ' . $sep_string . $column->name . $sep_string);
                         }

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -414,7 +414,12 @@ class LivewireDatatable extends Component
                     if ($column->select instanceof Expression) {
                         $sep_string = config('database.default') === 'pgsql' ? '"' : '`';
 
-                        return new Expression($column->select->getValue() . ' AS ' . $sep_string . $column->name . $sep_string);
+                        if(version_compare("10.0.0", app()->version()) == -1) {
+                            return new Expression($column->select->getQuery(DB::getQueryGrammar()) . ' AS ' . $sep_string . $column->name . $sep_string);
+                        }
+                        else {
+                            return new Expression($column->select->getQuery() . ' AS ' . $sep_string . $column->name . $sep_string);
+                        }
                     }
 
                     if (is_array($column->select)) {

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -417,7 +417,7 @@ class LivewireDatatable extends Component
                         if (version_compare("10.0.0", app()->version()) == -1) {
                             return new Expression($column->select->getValue(DB::getQueryGrammar()) . ' AS ' . $sep_string . $column->name . $sep_string);
                         } else {
-                            return new Expression($column->select->getQuery() . ' AS ' . $sep_string . $column->name . $sep_string);
+                            return new Expression($column->select->getValue() . ' AS ' . $sep_string . $column->name . $sep_string);
                         }
                     }
 

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -554,7 +554,7 @@ class LivewireDatatable extends Component
 
         $hidden = collect($this->columns)->filter->hidden->keys()->toArray();
 
-        session()->put([$this->sessionStorageKey() . $this->name . '_hidden_columns' => $hidden]);
+        session()->put([$this->sessionStorageKey() . '_hidden_columns' => $hidden]);
     }
 
     public function initialiseSearch()

--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -414,7 +414,7 @@ class LivewireDatatable extends Component
                     if ($column->select instanceof Expression) {
                         $sep_string = config('database.default') === 'pgsql' ? '"' : '`';
 
-                        if (version_compare("10.0.0", app()->version()) == -1) {
+                        if (version_compare('10.0.0', app()->version()) == -1) {
                             return new Expression($column->select->getValue(DB::getQueryGrammar()) . ' AS ' . $sep_string . $column->name . $sep_string);
                         } else {
                             return new Expression($column->select->getValue() . ' AS ' . $sep_string . $column->name . $sep_string);
@@ -444,8 +444,8 @@ class LivewireDatatable extends Component
             return $this->query->getModel()->getTable() . '.' . ($column->base ?? Str::before($column->name, ':'));
         }
 
-        $relations = explode('.', Str::before(($additional ?: $column->name), ':'));
-        $aggregate = Str::after(($additional ?: $column->name), ':');
+        $relations = explode('.', Str::before($additional ?: $column->name, ':'));
+        $aggregate = Str::after($additional ?: $column->name, ':');
 
         if (! method_exists($this->query->getModel(), $relations[0])) {
             return $additional ?: $column->name;


### PR DESCRIPTION
The storage key for the hidden columns was created with `$this->sessionStorageKey()` and `$this->name` but only loaded by using `$this->sessionStorageKey()`.
Old:
```PHP
public function setSessionStoredHidden()
    {
       //...
        session()->put([$this->sessionStorageKey() . $this->name . '_hidden_columns' => $hidden]);
    }

public function initialiseHiddenColumns()
    {
     //...
        if (session()->has($this->sessionStorageKey() . '_hidden_columns')) {
            $this->columns = collect($this->columns)->map(function ($column, $index) {
                $column['hidden'] = in_array($index, session()->get($this->sessionStorageKey() . '_hidden_columns'));

                return $column;
            })->toArray();
        }
    }
```

Changed: 
```PHP
session()->put([$this->sessionStorageKey() . $this->name . '_hidden_columns' => $hidden]);
```
to
```PHP
session()->put([$this->sessionStorageKey() . '_hidden_columns' => $hidden]);
```
